### PR TITLE
BUG. Impossible to flush the site on live environment.

### DIFF
--- a/code/Fluent.php
+++ b/code/Fluent.php
@@ -133,6 +133,7 @@ class Fluent extends Object {
 			: self::config()->persist_id_cms;
 		
 		// check session then cookies
+		Session::start();
 		if($locale = Session::get($key)) return $locale;
 		if($locale = Cookie::get($key)) return $locale;
 	}


### PR DESCRIPTION
Calling Session::get() before Session::start() will create an empty current Session object (look at Session::current_session()). And even SilverStripe calls Session::Start() later in /framework/main.php, Session::current_session() will return an empty "cached" Session object. So that's why permission check in /framework/main.php fails and you'll be redirected to login page.  

Actually I think that this is bug on SS side but it is faster and easier to make this workaround on fluent side than to do the changes in SilverStripe. :)

P.S. I've tested 3.1.0 branch with SS 3.1.0-rc1
