### PR TITLE
ENHANCEMENT: Allow custom home segment

### DIFF
--- a/code/FluentRootURLController.php
+++ b/code/FluentRootURLController.php
@@ -88,7 +88,7 @@ class FluentRootURLController extends RootURLController {
 		}
 		
 		$localeURL = Fluent::alias($locale);
-		$request->setUrl($localeURL.'/home/');
+		$request->setUrl($localeURL.'/'.RootURLController::get_homepage_link().'/');
 		$request->match($localeURL.'/$URLSegment//$Action', true);
 		
 		$controller = new ModelAsController();


### PR DESCRIPTION
Use the `homepage_link` from the SilverStripe config instead of the fixed `home` as URLSegment.
