### PR TITLE
FIX Composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 		"issues": "http://github.com/tractorcow/silverstripe-fluent/issues"
 	},
 	"require": {
-		"silverstripe/framework": "3.1.*-dev",
-		"silverstripe/cms": "3.1.*-dev",
+		"silverstripe/framework": "~3.1.1",
+		"silverstripe/cms": "~3.1.1",
 		"composer/installers": "*"
 	},
 	"extra": {


### PR DESCRIPTION
Silverstripe 3.1.1 is stable, so the dev branch is no longer necessary as a requirement, right?
