### PR TITLE
Zend Framework fails to detect temp dir.

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,4 +1,8 @@
 <?php
 
+// Zend_Cache temp directory setting
+$_ENV['TMPDIR'] = TEMP_FOLDER; // for *nix
+$_ENV['TMP'] = TEMP_FOLDER; // for Windows
+
 // Ensures routes etc are setup
 Fluent::init();


### PR DESCRIPTION
Sometimes Zend Framework fails to detect temp directory (it uses is_writable() which has some flaws). That's why SS sets these $_ENV variables [here](https://github.com/silverstripe/silverstripe-framework/blob/3.1/_config.php#L37).

The problem is that Fluent::init() is called even before framework/_config.php and you may get an error [here](https://github.com/tractorcow/silverstripe-fluent/blob/3.1/code/Fluent.php#L383).
