### PR TITLE
compatibility with homepagefordomain

### DIFF
--- a/code/routing/FluentRootURLController.php
+++ b/code/routing/FluentRootURLController.php
@@ -90,7 +90,13 @@ class FluentRootURLController extends RootURLController {
 		}
 		
 		$localeURL = Fluent::alias($locale);
-		$request->setUrl($localeURL.'/'.RootURLController::get_homepage_link().'/');
+		$homePageLink = RootURLController::get_homepage_link();
+		if(class_exists('HomepageForDomainExtension') && preg_match('/\//',$homePageLink)) {
+			$request->setUrl(RootURLController::get_homepage_link().'/');
+		}
+		else {
+			$request->setUrl($localeURL.'/'.RootURLController::get_homepage_link().'/');
+		}
 		$request->match($localeURL.'/$URLSegment//$Action', true);
 		
 		$controller = new ModelAsController();


### PR DESCRIPTION
when using fluent in connection with homepagefordomain the current locale is already included in the url. Not sure if this takes care of everything, but at least it does work while without it the whole thing does not work at all.
