### PR TITLE
make sure we get UTF-8 encoded localized strings

### DIFF
--- a/code/Fluent.php
+++ b/code/Fluent.php
@@ -383,7 +383,12 @@ class Fluent extends Object implements TemplateGlobalProvider {
 
 		// LC_NUMERIC causes SQL errors for some locales (comma as decimal indicator) so skip
 		foreach(array(LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_TIME) as $category) {
-			setlocale($category, $locale);
+			if (! strpos($locale,'.')){
+	  			setlocale($category, $locale.'.UTF-8');
+			}
+			else {
+	 			setlocale($category, $locale);
+			}
 		}
 
 		// Get date/time formats from Zend


### PR DESCRIPTION
When using locales like de_DE month names like März will be encoded in latin1 encoding while the webpage is in UTF-8 encoding. To get this in line, we append .UTF-8 if there is no '.' in the locale, since a '.' would indicate that some other encoding information is already present in the string.
