### PR TITLE
Reversing the position of haystack and needle

### DIFF
--- a/src/Extension/FluentBadgeExtension.php
+++ b/src/Extension/FluentBadgeExtension.php
@@ -8,9 +8,18 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
+use SilverStripe\Core\Config\Configurable;
 
 class FluentBadgeExtension extends Extension
 {
+    use Configurable;
+
+    /**
+     * @config
+     * @var boolean
+     */
+    private static $show_full_locale_badge = false;
+
     /**
      * Push a badge to indicate the language that owns the current item
      *
@@ -98,13 +107,23 @@ class FluentBadgeExtension extends Extension
             ]);
         }
 
+        if ($sourceLocale = $record->getSourceLocale()) {
+            if ($this->config()->get('show_full_locale_badge')) {
+                $localeTitle = $sourceLocale->getTitle();
+            } else {
+                $localeTitle = $sourceLocale->getLocaleSuffix();
+            }
+        } else {
+            $localeTitle = '&#9888;';
+        }
+
         return DBField::create_field(
             'HTMLFragment',
             sprintf(
                 '<span class="%s" title="%s">%s</span>',
                 implode(' ', $badgeClasses),
                 $tooltip,
-                $record->getSourceLocale()->getLocaleSuffix()
+                $localeTitle
             )
         );
     }

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -705,10 +705,14 @@ class FluentExtension extends DataExtension
      */
     public function getSourceLocale()
     {
-        $sourceLocale = $this->owner->getField('SourceLocale');
-        if ($sourceLocale) {
+        if ($sourceLocale = $this->owner->getField('SourceLocale')) {
             return Locale::getByLocale($sourceLocale);
         }
+
+        if ($locale = $this->owner->Locale) {
+            return Locale::getByLocale($locale);
+        }
+
         return Locale::getDefault();
     }
 

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -12,6 +12,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LiteralField;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
+use SilverStripe\Core\Config\Configurable;
 
 /**
  * Fluent extension for SiteTree
@@ -20,6 +21,8 @@ use TractorCow\Fluent\State\FluentState;
  */
 class FluentSiteTreeExtension extends FluentVersionedExtension
 {
+    use Configurable;
+
     /**
      * Determine if status messages are enabled
      *
@@ -29,6 +32,12 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     private static $locale_published_status_message = true;
 
     /**
+     * @config
+     * @var bool
+     */
+    private static $prefix_locale_in_link = true;
+
+    /**
      * Add the current locale's URL segment to the start of the URL
      *
      * @param string &$base
@@ -36,6 +45,11 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
      */
     public function updateRelativeLink(&$base, &$action)
     {
+        // Don't prefix locale if it's disabled
+        if (!$this->config()->get('prefix_locale_in_link')) {
+            return;
+        }
+
         // Don't inject locale to subpages
         if ($this->owner->ParentID && SiteTree::config()->get('nested_urls')) {
             return;
@@ -89,6 +103,11 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
      */
     public function updateLink(&$link, &$action, &$relativeLink)
     {
+        // Don't prefix locale if it's disabled
+        if (!$this->config()->get('prefix_locale_in_link')) {
+            return;
+        }
+
         // Get appropriate locale for this record
         $localeObj = $this->getRecordLocale();
         if (!$localeObj) {

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -334,6 +334,10 @@ class Locale extends DataObject
      */
     public function isLocale($locale)
     {
+        if (strlen($locale) > strlen($this->Locale)) {
+            return stripos(i18n::convert_rfc1766($locale), i18n::convert_rfc1766($this->Locale)) === 0;
+        }
+
         return stripos(i18n::convert_rfc1766($this->Locale), i18n::convert_rfc1766($locale)) === 0;
     }
 

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -87,6 +87,12 @@ class Locale extends DataObject
     ];
 
     /**
+     * @config
+     * @var boolean
+     */
+    private static $disable_implicit_default = false;
+
+    /**
      * @var ArrayList
      */
     protected $chain = null;
@@ -257,7 +263,7 @@ class Locale extends DataObject
      *
      * @param string|null|true $domain If provided, the default locale for the given domain will be returned.
      * If true, then the current state domain will be used (if in domain mode).
-     * @return Locale
+     * @return Locale|null
      */
     public static function getDefault($domain = null)
     {
@@ -272,8 +278,19 @@ class Locale extends DataObject
 
         // Get explicit or implicit default
         $locales = static::getLocales();
-        return $locales->filter('IsGlobalDefault', 1)->first()
-            ?: $locales->first();
+
+        // Return the first local which has IsGlobalDefault checked
+        if ($first = $locales->filter('IsGlobalDefault', 1)->first()) {
+            return $first;
+        }
+
+        // Return the first overall locale if implicit default flag is set
+        if (!static::config()->get('disable_implicit_default')) {
+            return $locales->first();
+        }
+
+        // No default!
+        return null;
     }
 
     /**

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -317,7 +317,7 @@ class Locale extends DataObject
      */
     public function isLocale($locale)
     {
-        return stripos(i18n::convert_rfc1766($locale), i18n::convert_rfc1766($this->Locale)) === 0;
+        return stripos(i18n::convert_rfc1766($this->Locale), i18n::convert_rfc1766($locale)) === 0;
     }
 
     /**


### PR DESCRIPTION
**Issue 1**

This fixes the issue where the browser may send a generic language header such as `en` or `cy` as opposed to the whole `en-GB` or `cy-GB`.

In that case we end up looking for `cy-GB` inside `cy` which `stripos` doesn't like. Flipping params fixes this issue.

**Issue 2**

Due to [legal reasons](https://en.wikipedia.org/wiki/Welsh_Language_Act_1993), no one language can be considered default. Fluent will currently return the first locale in the list regardless of the default flag being set or not. Introducing the `disable_implicit_default` flag to not have it do this allows some flexibility around this. By default, Fluent will behave as it currently does unless the flag is explicitly set to `true`.

**Issue 3**

Once the correct domain has been determined, there is no need to prefix the locale to URLs as Fluent will serve the page in the correct locale thereafter. Introducing the `prefix_locale_in_link` flag will allow us to disable this globally. Also it's really useful for outputting the canonical URL without the prefix. Again, by default Fluent will continue to behave as it currently does unless the flag is explicitly set to `false`.