### PR TITLE
Opt-out of cookie and session locale persistence (fixes #440)

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -240,19 +240,17 @@ Will cascade through different checks in order:
 1. Routing path (e.g. `/de/ueber-uns`)
 2. Request variable (e.g. `ueber-uns?FluentLocale=de`)
 3. Domain (e.g. `http://example.de/ueber-uns`)
-4. Session (if `DetectLocaleMiddleware.persist_session` is configured)
+4. Session (if a session is already started)
 5. Cookie (if `DetectLocaleMiddleware.persist_cookie` is configured)
 6. Request headers (if `FluentDirectorExtension.detect_locale` is configured)
 
-Additionally, detected locales will be set in session and cookies.
-This behaviour can be configured through `DetectLocaleMiddleware.persist_session`
-and `DetectLocaleMiddleware.persist_cookie`. To solely rely on stateless
-request data (routing path, request variable or domain),
-configure as follows:
+Additionally, detected locales will be set in cookies.
+This behaviour can be configured through `DetectLocaleMiddleware.persist_cookie`.
+To solely rely on sessions and stateless request data (routing path, request
+variable or domain), configure as follows:
 
 ```yaml
 TractorCow\Fluent\Middleware\DetectLocaleMiddleware:
-  persist_session: false
   persist_cookie: false
 ```
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -231,9 +231,33 @@ visible locales for this object.
 Note: Although these objects will be filtered in the front end, this filter is disabled
 in the CMS in order to allow access by site administrators in all locales.
 
-## Locale detection
+## Routing and Locale Detection
 
-When a visitor lands on the home page for the first time, Fluent can attempt to detect that user's locale based
+The `DetectLocaleMiddleware` will detect if a locale has been requested (or is default) and is not the current
+locale, and will redirect the user to that locale if needed.
+
+Will cascade through different checks in order:
+1. Routing path (e.g. `/de/ueber-uns`)
+2. Request variable (e.g. `ueber-uns?FluentLocale=de`)
+3. Domain (e.g. `http://example.de/ueber-uns`)
+4. Session (if `DetectLocaleMiddleware.persist_session` is configured)
+5. Cookie (if `DetectLocaleMiddleware.persist_cookie` is configured)
+6. Request headers (if `FluentDirectorExtension.detect_locale` is configured)
+
+Additionally, detected locales will be set in session and cookies.
+This behaviour can be configured through `DetectLocaleMiddleware.persist_session`
+and `DetectLocaleMiddleware.persist_cookie`. To solely rely on stateless
+request data (routing path, request variable or domain),
+configure as follows:
+
+```yaml
+TractorCow\Fluent\Middleware\DetectLocaleMiddleware:
+  persist_session: false
+  persist_cookie: false
+```
+
+When a visitor lands on the home page for the first time,
+Fluent can also attempt to detect that user's locale based
 on the `Accept-Language` http headers sent.
 
 This functionality can interfere with certain applications, such as Facebook Open Graph tools, so it

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -244,15 +244,20 @@ Will cascade through different checks in order:
 5. Cookie (if `DetectLocaleMiddleware.persist_cookie` is configured)
 6. Request headers (if `FluentDirectorExtension.detect_locale` is configured)
 
-Additionally, detected locales will be set in cookies.
-This behaviour can be configured through `DetectLocaleMiddleware.persist_cookie`.
-To solely rely on sessions and stateless request data (routing path, request
-variable or domain), configure as follows:
+Additionally, detected locales will be set in cookies. This behaviour can be configured through
+`DetectLocaleMiddleware.persist_cookie`. To solely rely on sessions (if session is started) and
+stateless request data (routing path, request variable or domain), configure as follows:
 
 ```yaml
 TractorCow\Fluent\Middleware\DetectLocaleMiddleware:
   persist_cookie: false
 ```
+
+Note that locales will only be persisted to the session if the session is already started. If
+you want to guarantee session persistence, you will need to ensure you call `->start()`
+on the session in the active HTTPRequest via a \_config.php file, or add a higher priority
+middleware that always starts the session ensuring it runs before `DetectLocaleMiddleware`.
+Be aware that prematurely starting sessions may complicate HTTP caching in your website.
 
 When a visitor lands on the home page for the first time,
 Fluent can also attempt to detect that user's locale based

--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -71,14 +71,6 @@ class DetectLocaleMiddleware implements HTTPMiddleware
     private static $persist_cookie_domain = null;
 
     /**
-     * Use sessions for locale persistence.
-     *
-     * @config
-     * @var bool
-     */
-    private static $persist_session = true;
-
-    /**
      * Whether cookies have already been set during {@link setPersistLocale()}
      *
      * @var bool
@@ -164,7 +156,8 @@ class DetectLocaleMiddleware implements HTTPMiddleware
         }
 
         // check session then cookies
-        if (static::config()->get('persist_session') && ($locale = $request->getSession()->get($key))) {
+        $session = $request->getSession();
+        if ($session->isStarted() && ($locale = $session->get($key))) {
             return $locale;
         }
 
@@ -195,11 +188,12 @@ class DetectLocaleMiddleware implements HTTPMiddleware
         }
 
         // Save locale
-        if (static::config()->get('persist_session')) {
+        $session = $request->getSession();
+        if ($session->isStarted()) {
             if ($locale) {
-                $request->getSession()->set($key, $locale);
+                $session->set($key, $locale);
             } else {
-                $request->getSession()->clear($key);
+                $session->clear($key);
             }
         }
 

--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -17,6 +17,8 @@ use TractorCow\Fluent\State\LocaleDetector;
 /**
  * DetectLocaleMiddleware will detect if a locale has been requested (or is default) and is not the current
  * locale, and will redirect the user to that locale if needed.
+ * Will cascade through different checks in order, see "configuration" docs for details.
+ * Additionally, detected locales will be set in session and cookies.
  */
 class DetectLocaleMiddleware implements HTTPMiddleware
 {
@@ -33,6 +35,16 @@ class DetectLocaleMiddleware implements HTTPMiddleware
         'frontend' => 'FluentLocale',
         'cms' => 'FluentLocale_CMS',
     ];
+
+    /**
+     * Use cookies for locale persistence.
+     * Caution: This can make it hard to activate HTTP caching,
+     * since many HTTP proxies (e.g. CDNs) won't cache with cookies.
+     *
+     * @config
+     * @var bool
+     */
+    private static $persist_cookie = true;
 
     /**
      * The expiry time in days for a locale persistence cookie
@@ -57,6 +69,14 @@ class DetectLocaleMiddleware implements HTTPMiddleware
      * @var string
      */
     private static $persist_cookie_domain = null;
+
+    /**
+     * Use sessions for locale persistence.
+     *
+     * @config
+     * @var bool
+     */
+    private static $persist_session = true;
 
     /**
      * Whether cookies have already been set during {@link setPersistLocale()}
@@ -84,8 +104,12 @@ class DetectLocaleMiddleware implements HTTPMiddleware
             i18n::set_locale($state->getLocale());
         }
 
-        // Always persist the current locale
-        $this->setPersistLocale($request, $state->getLocale());
+        // Persist the current locale if it has a value.
+        // Distinguishes null from empty strings in order to unset locales.
+        $newLocale = $state->getLocale();
+        if (!is_null($newLocale)) {
+            $this->setPersistLocale($request, $newLocale);
+        }
 
         return $delegate($request);
     }
@@ -140,11 +164,11 @@ class DetectLocaleMiddleware implements HTTPMiddleware
         }
 
         // check session then cookies
-        if ($locale = $request->getSession()->get($key)) {
+        if (static::config()->get('persist_session') && $locale = $request->getSession()->get($key)) {
             return $locale;
         }
 
-        if ($locale = Cookie::get($key)) {
+        if (static::config()->get('persist_cookie') && $locale = Cookie::get($key)) {
             return $locale;
         }
 
@@ -171,14 +195,16 @@ class DetectLocaleMiddleware implements HTTPMiddleware
         }
 
         // Save locale
-        if ($locale) {
-            $request->getSession()->set($key, $locale);
-        } else {
-            $request->getSession()->clear($key);
+        if (static::config()->get('persist_session')) {
+            if ($locale) {
+                $request->getSession()->set($key, $locale);
+            } else {
+                $request->getSession()->clear($key);
+            }
         }
 
         // Don't set cookie if headers already sent
-        if (!headers_sent()) {
+        if (static::config()->get('persist_cookie') && !headers_sent()) {
             Cookie::set(
                 $key,
                 $locale,

--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -164,11 +164,11 @@ class DetectLocaleMiddleware implements HTTPMiddleware
         }
 
         // check session then cookies
-        if (static::config()->get('persist_session') && $locale = $request->getSession()->get($key)) {
+        if (static::config()->get('persist_session') && ($locale = $request->getSession()->get($key))) {
             return $locale;
         }
 
-        if (static::config()->get('persist_cookie') && $locale = Cookie::get($key)) {
+        if (static::config()->get('persist_cookie') && ($locale = Cookie::get($key))) {
             return $locale;
         }
 

--- a/tests/php/Middleware/DetectLocaleMiddlewareTest.php
+++ b/tests/php/Middleware/DetectLocaleMiddlewareTest.php
@@ -153,7 +153,9 @@ class DetectLocaleMiddlewareTest extends SapphireTest
         $request->setSession($sessionMock);
 
         Cookie::set($key, $newLocale);
-        $middleware->process($request, function () {});
+        $middleware->process($request, function () {
+            // no-op
+        });
 
         // TODO PHPUnit's headers_sent() always returns true, so we can't check for cookie values.
         // PHPUnit has process isolation for this purpose, but we can't use it because autoloading breaks.
@@ -175,7 +177,9 @@ class DetectLocaleMiddlewareTest extends SapphireTest
         $sessionMock->expects($this->once())->method('set')->with($key, $newLocale);
         $request->setSession($sessionMock);
 
-        $middleware->process($request, function () {});
+        $middleware->process($request, function () {
+            // no-op
+        });
 
         // TODO PHPUnit's headers_sent() always returns true, so we can't check for cookie values.
         // PHPUnit has process isolation for this purpose, but we can't use it because autoloading breaks.
@@ -198,7 +202,9 @@ class DetectLocaleMiddlewareTest extends SapphireTest
         $sessionMock->expects($this->never())->method('set');
         $request->setSession($sessionMock);
 
-        $middleware->process($request, function () {});
+        $middleware->process($request, function () {
+            // no-op
+        });
 
         // TODO PHPUnit's headers_sent() always returns true, so we can't check for cookie values.
         // PHPUnit has process isolation for this purpose, but we can't use it because autoloading breaks.
@@ -225,7 +231,9 @@ class DetectLocaleMiddlewareTest extends SapphireTest
         // $sessionMock->expects($this->once())->method('set')->with($key, $this->globalDefaultLocale);
         // $request->setSession($sessionMock);
         //
-        // $middleware->process($request, function () {});
+        // $middleware->process($request, function () {
+        //     // no-op
+        // });
         //
         // $this->assertEquals($this->globalDefaultLocale, Cookie::get($key));
     }

--- a/tests/php/Middleware/DetectLocaleMiddlewareTest.php
+++ b/tests/php/Middleware/DetectLocaleMiddlewareTest.php
@@ -141,7 +141,7 @@ class DetectLocaleMiddlewareTest extends SapphireTest
     {
         $newLocale = 'fr_FR';
         $middleware = $this->middleware;
-        $key = $this->middleware->getPersistKey();
+        $key = $middleware->getPersistKey();
         $request = new HTTPRequest('GET', '/');
 
         $sessionData = [];
@@ -166,7 +166,7 @@ class DetectLocaleMiddlewareTest extends SapphireTest
     {
         $newLocale = 'fr_FR';
         $middleware = $this->middleware;
-        $key = $this->middleware->getPersistKey();
+        $key = $middleware->getPersistKey();
         $request = new HTTPRequest('GET', '/');
 
         $sessionData = [$key => $newLocale];
@@ -191,7 +191,7 @@ class DetectLocaleMiddlewareTest extends SapphireTest
         $newLocale = 'fr_FR';
         $middleware = $this->middleware;
         $middleware->config()->update('persist_session', false);
-        $key = $this->middleware->getPersistKey();
+        $key = $middleware->getPersistKey();
         $request = new HTTPRequest('GET', '/');
 
         $sessionData = [$key => $newLocale];

--- a/tests/php/Middleware/DetectLocaleMiddlewareTest.php
+++ b/tests/php/Middleware/DetectLocaleMiddlewareTest.php
@@ -4,7 +4,9 @@ namespace TractorCow\Fluent\Tests\Middleware;
 
 use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\Cookie;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
@@ -22,6 +24,11 @@ class DetectLocaleMiddlewareTest extends SapphireTest
      */
     protected $middleware;
 
+    /**
+     * @var string
+     */
+    protected $globalDefaultLocale;
+
     protected function setUp()
     {
         parent::setUp();
@@ -35,6 +42,9 @@ class DetectLocaleMiddlewareTest extends SapphireTest
         // Clear cache
         Locale::clearCached();
         Domain::clearCached();
+
+        // Get defaults from fixture
+        $this->globalDefaultLocale = Locale::get()->find('IsGlobalDefault', 1)->Locale;
     }
 
     public function testGetPersistKey()
@@ -108,5 +118,115 @@ class DetectLocaleMiddlewareTest extends SapphireTest
         $middleware->process($request, function () {
             // no-op
         });
+    }
+
+    public function testLocaleIsOnlyPersistedWhenSet()
+    {
+        $request = new HTTPRequest('GET', '/');
+        // not calling setLocale(), should default to null
+
+        /** @var DetectLocaleMiddleware|PHPUnit_Framework_MockObject_MockObject $middleware */
+        $middleware = $this->getMockBuilder(DetectLocaleMiddleware::class)
+            ->setMethods(['getLocale', 'setPersistLocale'])
+            ->getMock();
+
+        $middleware->expects($this->never())->method('setPersistLocale');
+
+        $middleware->process($request, function () {
+            // no-op
+        });
+    }
+
+    public function testLocaleIsPersistedFromCookie()
+    {
+        $newLocale = 'fr_FR';
+        $middleware = $this->middleware;
+        $key = $this->middleware->getPersistKey();
+        $request = new HTTPRequest('GET', '/');
+
+        $sessionData = [];
+        $sessionMock = $this->getMockBuilder(Session::class)
+            ->setMethods(['set'])
+            ->setConstructorArgs([$sessionData])
+            ->getMock();
+        $sessionMock->expects($this->once())->method('set')->with($key, $newLocale);
+        $request->setSession($sessionMock);
+
+        Cookie::set($key, $newLocale);
+        $middleware->process($request, function () {});
+
+        // TODO PHPUnit's headers_sent() always returns true, so we can't check for cookie values.
+        // PHPUnit has process isolation for this purpose, but we can't use it because autoloading breaks.
+        // $this->assertEquals($newLocale, Cookie::get($key));
+    }
+
+    public function testLocaleIsPersistedFromSession()
+    {
+        $newLocale = 'fr_FR';
+        $middleware = $this->middleware;
+        $key = $this->middleware->getPersistKey();
+        $request = new HTTPRequest('GET', '/');
+
+        $sessionData = [$key => $newLocale];
+        $sessionMock = $this->getMockBuilder(Session::class)
+            ->setMethods(['set'])
+            ->setConstructorArgs([$sessionData])
+            ->getMock();
+        $sessionMock->expects($this->once())->method('set')->with($key, $newLocale);
+        $request->setSession($sessionMock);
+
+        $middleware->process($request, function () {});
+
+        // TODO PHPUnit's headers_sent() always returns true, so we can't check for cookie values.
+        // PHPUnit has process isolation for this purpose, but we can't use it because autoloading breaks.
+        // $this->assertEquals($newLocale, Cookie::get($key));
+    }
+
+    public function testLocaleIsNotPersistedFromSessionWhenPersistSessionFalse()
+    {
+        $newLocale = 'fr_FR';
+        $middleware = $this->middleware;
+        $middleware->config()->update('persist_session', false);
+        $key = $this->middleware->getPersistKey();
+        $request = new HTTPRequest('GET', '/');
+
+        $sessionData = [$key => $newLocale];
+        $sessionMock = $this->getMockBuilder(Session::class)
+            ->setMethods(['set'])
+            ->setConstructorArgs([$sessionData])
+            ->getMock();
+        $sessionMock->expects($this->never())->method('set');
+        $request->setSession($sessionMock);
+
+        $middleware->process($request, function () {});
+
+        // TODO PHPUnit's headers_sent() always returns true, so we can't check for cookie values.
+        // PHPUnit has process isolation for this purpose, but we can't use it because autoloading breaks.
+        // $this->assertEquals($this->globalDefaultLocale, Cookie::get($key));
+    }
+
+    public function testLocaleIsNotPersistedFromCookieWhenPersistCookieFalse()
+    {
+        // TODO PHPUnit's headers_sent() always returns true, so we can't check for cookie values.
+        // PHPUnit has process isolation for this purpose, but we can't use it because autoloading breaks.
+        $this->markTestIncomplete();
+
+        // $newLocale = 'fr_FR';
+        // $middleware = $this->middleware;
+        // $middleware->config()->update('persist_cookie', false);
+        // $key = $this->middleware->getPersistKey();
+        // $request = new HTTPRequest('GET', '/');
+        //
+        // $sessionData = [$key => $newLocale];
+        // $sessionMock = $this->getMockBuilder(Session::class)
+        //     ->setMethods(['set'])
+        //     ->setConstructorArgs([$sessionData])
+        //     ->getMock();
+        // $sessionMock->expects($this->once())->method('set')->with($key, $this->globalDefaultLocale);
+        // $request->setSession($sessionMock);
+        //
+        // $middleware->process($request, function () {});
+        //
+        // $this->assertEquals($this->globalDefaultLocale, Cookie::get($key));
     }
 }


### PR DESCRIPTION
It kills any HTTP caching otherwise. The distinction between `is_null` and "empty string" isn't ideal of course.

See https://github.com/tractorcow/silverstripe-fluent/issues/440