### PR TITLE
FIX Opt-in performance fix for many consecutive lookups using isLocalisedInStage

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DB;
@@ -369,7 +370,7 @@ class FluentVersionedExtension extends FluentExtension
      * @param array $options A map of hints about what should be cached. "numChildrenMethod" and
      *                       "childrenMethod" are allowed keys.
      */
-    public function onPrepopulateTreeDataCache(DataList $recordList = null, array $options = [])
+    public function onPrepopulateTreeDataCache($recordList = null, array $options = [])
     {
         if (!Config::inst()->get(self::class, 'prepopulate_localecontent_cache')) {
             return;
@@ -388,7 +389,9 @@ class FluentVersionedExtension extends FluentExtension
      * Prepopulate the cache of IDs in a locale, to optimise batch calls to isLocalisedInStage.
      *
      * @param string $locale
-     * @param string $dataObject
+     * @param $dataObjectClass
+     * @param bool $populateLive
+     * @param bool $populateDraft
      */
     public static function prepoulateIdsInLocale($locale, $dataObjectClass, $populateLive = true, $populateDraft = true)
     {

--- a/tests/php/Extension/FluentVersionedExtensionTest.php
+++ b/tests/php/Extension/FluentVersionedExtensionTest.php
@@ -6,6 +6,7 @@ use Page;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\SapphireTest;
 use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
+use TractorCow\Fluent\Extension\FluentVersionedExtension;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
@@ -27,6 +28,8 @@ class FluentVersionedExtensionTest extends SapphireTest
         // Clear cache
         Locale::clearCached();
         Domain::clearCached();
+        (new FluentVersionedExtension)->flushCache();
+
         FluentState::singleton()
             ->setLocale('en_NZ')
             ->setIsDomainMode(false);
@@ -56,7 +59,6 @@ class FluentVersionedExtensionTest extends SapphireTest
         $this->assertTrue($page->existsInLocale());
     }
 
-    /** @group wip */
     public function testSourceLocaleIsCurrentWhenPageExistsInIt()
     {
         // Read from the locale that the page exists in already
@@ -64,5 +66,47 @@ class FluentVersionedExtensionTest extends SapphireTest
         $page = $this->objFromFixture(Page::class, 'home');
 
         $this->assertEquals('en_NZ', $page->getSourceLocale()->Locale);
+    }
+
+    public function testLocalisedStageCacheIsUsedForIsLocalisedInLocale()
+    {
+        /** @var Page $page */
+        $page = $this->objFromFixture(Page::class, 'home');
+
+        /** @var FluentVersionedExtension $extension */
+        $extension = $this->getMockBuilder(FluentVersionedExtension::class)
+            ->setMethods(['findRecordInLocale'])
+            ->getMock();
+        $extension->setOwner($page);
+
+        // We only expect one call to this method, because subsequent calls should be cached
+        $extension->expects($this->once())->method('findRecordInLocale')->willReturn('foo');
+
+        // Initial request
+        $result = $extension->isPublishedInLocale('en_NZ');
+        $this->assertSame('foo', $result, 'Original method result is returned');
+
+        // Checking the cache
+        $result2 = $extension->isPublishedInLocale('en_NZ');
+        $this->assertSame('foo', $result2, 'Cached result is returned');
+    }
+
+    public function testIdsInLocaleCacheIsUsedForIsLocalisedInLocale()
+    {
+        // Optimistically generate the cache
+        FluentVersionedExtension::prepoulateIdsInLocale('en_NZ', Page::class, true, true);
+
+        /** @var Page $page */
+        $page = $this->objFromFixture(Page::class, 'home');
+
+        /** @var FluentVersionedExtension $extension */
+        $extension = $this->getMockBuilder(FluentVersionedExtension::class)
+            ->setMethods(['findRecordInLocale'])
+            ->getMock();
+        $extension->setOwner($page);
+
+        // We expect the lookup method to never get called, because the results are optimistically cached
+        $extension->expects($this->never())->method('findRecordInLocale');
+        $this->assertTrue($extension->isPublishedInLocale('en_NZ'), 'Fixtured page is published');
     }
 }


### PR DESCRIPTION
This PR adds a static method to pre-populate a cache of object IDs that exist in the given locale. This can be opted into by calling this method from appropriate user-code (or user-code extension) or alternatively by providing a list of classes that should be pre-populated (done when the first call of `isLocalisedInStage` is performed for that class).

Ideally I wouldn't have this config option but it is currently quite difficult to find a location to prepopulate this cache when running the SiteTree, although I'm open to suggestions here and more than happy to remove the configuration part of this PR.

Fixes #467 