### PR TITLE
FIX Performance update - reduces the use of filter on multiple subsequent calls to getByLocale

### DIFF
--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -92,6 +92,11 @@ class Locale extends DataObject
     protected $chain = null;
 
     /**
+     * @var Locale[]
+     */
+    protected static $locales_by_title;
+
+    /**
      * Get internal title for this locale
      *
      * @return string
@@ -303,10 +308,15 @@ class Locale extends DataObject
             return $locale;
         }
 
+        if (!static::$locales_by_title) {
+            static::$locales_by_title = [];
+            foreach (Locale::getCached() as $localeObj) {
+                static::$locales_by_title[$localeObj->Locale] = $localeObj;
+            }
+        }
+
         // Get filtered locale
-        return Locale::getCached()
-            ->filter('Locale', $locale)
-            ->first();
+        return isset(static::$locales_by_title[$locale]) ? static::$locales_by_title[$locale] : null;
     }
 
     /**


### PR DESCRIPTION
This PR caches the call of `Locale::getCached` and keys is by the actual locale title. Calls to `getByLocale` are just an array lookup by key now :+1:.