### PR TITLE
FIX ReadVersions GraphQL operation now has the current fluent locale added as a filter

### DIFF
--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -20,3 +20,7 @@ SilverStripe\CMS\Controllers\CMSMain:
 SilverStripe\Versioned\VersionedGridFieldItemRequest:
   extensions:
     FluentBadgeExtension: TractorCow\Fluent\Extension\FluentBadgeExtension
+
+SilverStripe\Versioned\GraphQL\Operations\ReadVersions:
+  extensions:
+    FluentReadVersionsExtension: TractorCow\Fluent\Extension\FluentReadVersionsExtension

--- a/src/Extension/FluentReadVersionsExtension.php
+++ b/src/Extension/FluentReadVersionsExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TractorCow\Fluent\Extension;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\DataList;
+use TractorCow\Fluent\State\FluentState;
+
+/**
+ * Available since SilverStripe 4.3.x
+ */
+class FluentReadVersionsExtension extends Extension
+{
+    /**
+     * Set a filter on the current locale in SourceLocale alias field. This field is added by
+     * FluentExtension::augmentSQL, and this list is used in the history viewer via a GraphQL query.
+     *
+     * @param DataList &$list
+     */
+    public function updateList(DataList &$list)
+    {
+        $locale = FluentState::singleton()->getLocale();
+
+        $query = $list->dataQuery();
+        $query->having(['"SourceLocale" = ?' => $locale]);
+
+        $list = $list->setDataQuery($query);
+    }
+}

--- a/tests/php/Extension/FluentReadVersionsExtensionTest.php
+++ b/tests/php/Extension/FluentReadVersionsExtensionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Extension;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use TractorCow\Fluent\Extension\FluentReadVersionsExtension;
+use TractorCow\Fluent\State\FluentState;
+
+class FluentReadVersionsExtensionTest extends SapphireTest
+{
+    public function testUpdateListSetsCurrentLocaleIntoHavingInQuery()
+    {
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState->setLocale('en_NZ');
+            $list = SiteTree::get();
+
+            $extension = new FluentReadVersionsExtension();
+            $extension->updateList($list);
+
+            $this->assertContains(
+                ['"SourceLocale" = ?' => ['en_NZ']],
+                $list->dataQuery()->getFinalisedQuery()->getHaving(),
+                'Fluent adds the current locale to the underlying list\'s data query'
+            );
+        });
+    }
+}


### PR DESCRIPTION
Requires https://github.com/silverstripe/silverstripe-versioned/pull/182

Resolves https://github.com/tractorcow-farm/silverstripe-fluent/issues/414