### PR TITLE
FIX Removing specific ID check for performance improvements

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -330,7 +330,7 @@ class FluentVersionedExtension extends FluentExtension
         }
 
         // Check for a cached item in the full list of all objects. These are populated optimistically.
-        if (isset(static::$idsInLocaleCache[$locale][$table][$this->owner->ID])) {
+        if (isset(static::$idsInLocaleCache[$locale][$table])) {
             return isset(static::$idsInLocaleCache[$locale][$table][$this->owner->ID]);
         }
 


### PR DESCRIPTION
The ID check was not needed as the query that populates the cache fetches for the whole table. The absense of an ID means that the record does not exist in the current locale. With the ID check, it will always use the fallback when we could actually just return false.