### PR TITLE
FIX: Add _complete flag to ensure that missing record requests are ca…

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -57,13 +57,6 @@ class FluentVersionedExtension extends FluentExtension
     ];
 
     /**
-     * Cache of published status of this record
-     *
-     * @var array
-     */
-    protected static $localisedStageCache = [];
-
-    /**
      * Array of objectIds keyed by table (ie. stage) and locale. This knows ALL object IDs that exist in the given table
      * and locale.
      *
@@ -331,17 +324,15 @@ class FluentVersionedExtension extends FluentExtension
 
         // Check for a cached item in the full list of all objects. These are populated optimistically.
         if (isset(static::$idsInLocaleCache[$locale][$table][$this->owner->ID])) {
-            return isset(static::$idsInLocaleCache[$locale][$table][$this->owner->ID]);
-        }
+            return true;
 
-        // Check cache from local instance calls
-        $key = $table . '/' . $locale . '/' . $this->owner->ID;
-        if (isset(static::$localisedStageCache[$key])) {
-            return static::$localisedStageCache[$key];
+        } elseif (!empty(static::$idsInLocaleCache[$locale][$table]['_complete'])) {
+            return false;
         }
 
         // Set cache and return
-        return static::$localisedStageCache[$key] = $this->findRecordInLocale($locale, $table, $this->owner->ID);
+        return static::$idsInLocaleCache[$locale][$table][$this->owner->ID]
+            = $this->findRecordInLocale($locale, $table, $this->owner->ID);
     }
 
     /**
@@ -371,7 +362,6 @@ class FluentVersionedExtension extends FluentExtension
     public function flushCache()
     {
         static::$idsInLocaleCache = [];
-        static::$localisedStageCache = [];
     }
 
     /**
@@ -437,6 +427,7 @@ class FluentVersionedExtension extends FluentExtension
 
             // We need to execute ourselves as the param is lost from the subSelect
             self::$idsInLocaleCache[$locale][$table] = array_combine($ids, $ids);
+            self::$idsInLocaleCache[$locale][$table]['_complete'] = true;
         }
     }
 }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -13,6 +13,7 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\View\ArrayData;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
+use TractorCow\Fluent\Extension\FluentVersionedExtension;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
@@ -37,6 +38,8 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         // Clear cache
         Locale::clearCached();
         Domain::clearCached();
+        (new FluentVersionedExtension)->flushCache();
+
         FluentState::singleton()
             ->setLocale('de_DE')
             ->setIsDomainMode(false);

--- a/tests/php/Extension/FluentVersionedExtensionTest.php
+++ b/tests/php/Extension/FluentVersionedExtensionTest.php
@@ -80,15 +80,15 @@ class FluentVersionedExtensionTest extends SapphireTest
         $extension->setOwner($page);
 
         // We only expect one call to this method, because subsequent calls should be cached
-        $extension->expects($this->once())->method('findRecordInLocale')->willReturn('foo');
+        $extension->expects($this->once())->method('findRecordInLocale')->willReturn(true);
 
         // Initial request
         $result = $extension->isPublishedInLocale('en_NZ');
-        $this->assertSame('foo', $result, 'Original method result is returned');
+        $this->assertSame(true, $result, 'Original method result is returned');
 
         // Checking the cache
         $result2 = $extension->isPublishedInLocale('en_NZ');
-        $this->assertSame('foo', $result2, 'Cached result is returned');
+        $this->assertSame(true, $result2, 'Cached result is returned');
     }
 
     public function testIdsInLocaleCacheIsUsedForIsLocalisedInLocale()


### PR DESCRIPTION
…ched

FIX: Remove unnecessary 2nd cache implementation.

This code improves performance when there are a significant number of
draft pages. Related, there was a duplicate implementation of caching
that wasn’t really necessary.