### PR TITLE
BUG Prevent force-creating empty sessions

### DIFF
--- a/_config/tests.yml
+++ b/_config/tests.yml
@@ -1,0 +1,8 @@
+---
+Name: fluentsapphiretest
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Dev\State\SapphireTestState:
+    properties:
+      States:
+        fluent: '%$TractorCow\Fluent\Dev\FluentTestState'

--- a/src/Dev/FluentTestState.php
+++ b/src/Dev/FluentTestState.php
@@ -1,0 +1,47 @@
+<?php
+namespace TractorCow\Fluent\Dev;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\State\TestState;
+use TractorCow\Fluent\Model\Locale;
+
+class FluentTestState implements TestState
+{
+    /**
+     * Called on setup
+     *
+     * @param SapphireTest $test
+     */
+    public function setUp(SapphireTest $test)
+    {
+        // Clear locale static caching between tests.
+        Locale::clearCached();
+    }
+
+    /**
+     * Called on tear down
+     *
+     * @param SapphireTest $test
+     */
+    public function tearDown(SapphireTest $test)
+    {
+    }
+
+    /**
+     * Called once on setup
+     *
+     * @param string $class Class being setup
+     */
+    public function setUpOnce($class)
+    {
+    }
+
+    /**
+     * Called once on tear down
+     *
+     * @param string $class Class being torn down
+     */
+    public function tearDownOnce($class)
+    {
+    }
+}

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -325,7 +325,6 @@ class FluentVersionedExtension extends FluentExtension
         // Check for a cached item in the full list of all objects. These are populated optimistically.
         if (isset(static::$idsInLocaleCache[$locale][$table][$this->owner->ID])) {
             return true;
-
         } elseif (!empty(static::$idsInLocaleCache[$locale][$table]['_complete'])) {
             return false;
         }

--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -189,7 +189,7 @@ class DetectLocaleMiddleware implements HTTPMiddleware
 
         // Save locale
         $session = $request->getSession();
-        if ($session->isStarted()) {
+        if ($session->isStarted() && $session->getAll()) {
             if ($locale) {
                 $session->set($key, $locale);
             } else {

--- a/tests/php/Middleware/DetectLocaleMiddlewareTest.php
+++ b/tests/php/Middleware/DetectLocaleMiddlewareTest.php
@@ -146,10 +146,11 @@ class DetectLocaleMiddlewareTest extends SapphireTest
 
         $sessionData = [];
         $sessionMock = $this->getMockBuilder(Session::class)
-            ->setMethods(['set'])
+            ->setMethods(['set', 'getAll'])
             ->setConstructorArgs([$sessionData])
             ->getMock();
         $sessionMock->expects($this->once())->method('set')->with($key, $newLocale);
+        $sessionMock->expects($this->once())->method('getAll')->willReturn([true]);
         $request->setSession($sessionMock);
 
         Cookie::set($key, $newLocale);
@@ -175,7 +176,7 @@ class DetectLocaleMiddlewareTest extends SapphireTest
             ->setConstructorArgs([$sessionData])
             ->getMock();
 
-        $sessionMock->expects($this->exactly(2))->method('isStarted')->willReturn(true);
+        $sessionMock->expects($this->any())->method('isStarted')->willReturn(true);
         $sessionMock->expects($this->once())->method('set')->with($key, $newLocale);
         $request->setSession($sessionMock);
 
@@ -201,7 +202,7 @@ class DetectLocaleMiddlewareTest extends SapphireTest
             ->setConstructorArgs([$sessionData])
             ->getMock();
 
-        $sessionMock->expects($this->exactly(2))->method('isStarted')->willReturn(false);
+        $sessionMock->expects($this->any())->method('isStarted')->willReturn(false);
         $sessionMock->expects($this->never())->method('set');
         $request->setSession($sessionMock);
 


### PR DESCRIPTION
Reasoning is that all sessions are always started (isStarted() is true after SessionMiddleware is run), but not all sessions eventuate into a session in finalise. This check catches that.