### PR TITLE
Adding TestState to clear static locale caching between tests

### DIFF
--- a/_config/tests.yml
+++ b/_config/tests.yml
@@ -1,0 +1,8 @@
+---
+Name: fluentsapphiretest
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Dev\State\SapphireTestState:
+    properties:
+      States:
+        fluent: '%$TractorCow\Fluent\Dev\FluentTestState'

--- a/src/Dev/FluentTestState.php
+++ b/src/Dev/FluentTestState.php
@@ -1,0 +1,47 @@
+<?php
+namespace TractorCow\Fluent\Dev;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\State\TestState;
+use TractorCow\Fluent\Model\Locale;
+
+class FluentTestState implements TestState
+{
+    /**
+     * Called on setup
+     *
+     * @param SapphireTest $test
+     */
+    public function setUp(SapphireTest $test)
+    {
+        // Clear locale static caching between tests.
+        Locale::clearCached();
+    }
+
+    /**
+     * Called on tear down
+     *
+     * @param SapphireTest $test
+     */
+    public function tearDown(SapphireTest $test)
+    {
+    }
+
+    /**
+     * Called once on setup
+     *
+     * @param string $class Class being setup
+     */
+    public function setUpOnce($class)
+    {
+    }
+
+    /**
+     * Called once on tear down
+     *
+     * @param string $class Class being torn down
+     */
+    public function tearDownOnce($class)
+    {
+    }
+}


### PR DESCRIPTION
This resolves an issue where tests (in a "key project") were failing due to some locale caching with various locale configuration. This test state busts the locale caching between every test (as it probably should do)