### PR TITLE
FIX Quote Injector service references, will break in Symfony 4

### DIFF
--- a/_config/routing.yml
+++ b/_config/routing.yml
@@ -11,5 +11,5 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\Director:
     properties:
       Middlewares:
-        InitStateMiddleware: %$TractorCow\Fluent\Middleware\InitStateMiddleware
-        DetectLocaleMiddleware: %$TractorCow\Fluent\Middleware\DetectLocaleMiddleware
+        InitStateMiddleware: '%$TractorCow\Fluent\Middleware\InitStateMiddleware'
+        DetectLocaleMiddleware: '%$TractorCow\Fluent\Middleware\DetectLocaleMiddleware'


### PR DESCRIPTION
```
PHP Deprecated: Not quoting the scalar "%$TractorCow\Fluent\Middleware\InitStateMiddleware" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 8. in /Users/robbieaverill/dev/ss43/vendor/symfony/yaml/Inline.php on line 357
PHP Deprecated: Not quoting the scalar "%$TractorCow\Fluent\Middleware\DetectLocaleMiddleware" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 9. in /Users/robbieaverill/dev/ss43/vendor/symfony/yaml/Inline.php on line 357
```