### PR TITLE
FIX Only updateList for objects that have the FluentVersionedExtension

### DIFF
--- a/src/Extension/FluentReadVersionsExtension.php
+++ b/src/Extension/FluentReadVersionsExtension.php
@@ -5,6 +5,7 @@ namespace TractorCow\Fluent\Extension;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
 use TractorCow\Fluent\State\FluentState;
 
 /**
@@ -20,7 +21,13 @@ class FluentReadVersionsExtension extends Extension
      */
     public function updateList(DataList &$list)
     {
-        if (Injector::inst()->get($list->dataClass())->hasExtension(FluentVersionedExtension::class)) {
+        /** @var DataObject $singleton */
+        $singleton = Injector::inst()->get($list->dataClass());
+        $locale = $list->dataQuery()->getQueryParam('Fluent.Locale') ?: FluentState::singleton()->getLocale();
+        if (!$singleton->hasExtension(FluentExtension::class)
+            || !$singleton->hasField('SourceLocale')
+            || !$locale
+        ) {
             return;
         }
 

--- a/src/Extension/FluentReadVersionsExtension.php
+++ b/src/Extension/FluentReadVersionsExtension.php
@@ -3,6 +3,7 @@
 namespace TractorCow\Fluent\Extension;
 
 use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataList;
 use TractorCow\Fluent\State\FluentState;
 
@@ -19,6 +20,10 @@ class FluentReadVersionsExtension extends Extension
      */
     public function updateList(DataList &$list)
     {
+        if (Injector::inst()->get($list->dataClass())->hasExtension(FluentVersionedExtension::class)) {
+            return;
+        }
+
         $locale = FluentState::singleton()->getLocale();
 
         $query = $list->dataQuery();

--- a/tests/php/Extension/FluentReadVersionsExtensionTest.php
+++ b/tests/php/Extension/FluentReadVersionsExtensionTest.php
@@ -5,10 +5,19 @@ namespace TractorCow\Fluent\Tests\Extension;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\SapphireTest;
 use TractorCow\Fluent\Extension\FluentReadVersionsExtension;
+use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
 use TractorCow\Fluent\State\FluentState;
 
 class FluentReadVersionsExtensionTest extends SapphireTest
 {
+    protected $usesDatabase = true;
+
+    protected static $required_extensions = [
+        SiteTree::class => [
+            FluentSiteTreeExtension::class,
+        ],
+    ];
+
     public function testUpdateListSetsCurrentLocaleIntoHavingInQuery()
     {
         FluentState::singleton()->withState(function (FluentState $newState) {


### PR DESCRIPTION
Prevents breaking when fluent is not enabled, or querying objects that are not fluent