### PR TITLE
Display the current domain's default locale url segment in base urls

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -270,3 +270,12 @@ is turned off by default. To turn it on set the below setting:
 TractorCow\Fluent\Extension\FluentDirectorExtension:
   detect_locale: true
 ```
+
+## Use full default base URL for all locales
+
+By default, fluent will return `/` as the default locale's default base url. To enforce the use of full default base URLs for all locales (e.g always return `/en/`), set the below setting:
+
+```yaml
+TractorCow\Fluent\Model\Locale:
+  use_full_default_base_url: true
+```

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -4,6 +4,7 @@ namespace TractorCow\Fluent\Model;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
@@ -24,6 +25,9 @@ use Symbiote\GridFieldExtensions\GridFieldAddNewInlineButton;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 use TractorCow\Fluent\State\FluentState;
+
+use SilverStripe\Core\Injector\Injector;
+use Psr\Log\LoggerInterface;
 
 /**
  * @property string $Title
@@ -85,6 +89,13 @@ class Locale extends DataObject
             'to' => 'Locale',
         ],
     ];
+
+    /**
+     * Display the current domain's default locale url segment in base urls
+     *
+     * @var bool
+     */
+    private static $use_full_default_base_url = false;
 
     /**
      * @var ArrayList
@@ -455,8 +466,16 @@ class Locale extends DataObject
             $base = Controller::join_links($domain->Link(), $base);
         }
 
-        // Append locale urlsegment if a non-default locale
-        if (!$this->getIsDefault()) {
+        // Determine if base suffix should be appended
+        $append = true;
+
+        if ($this->getIsDefault()) {
+            // Apply config
+            $append = Config::inst()->get(self::class, 'use_full_default_base_url');
+        }
+
+        if ($append) {
+            // Append locale url segment
             $base = Controller::join_links($base, $this->getURLSegment(), '/');
         }
 

--- a/tests/php/Model/LocaleTest.php
+++ b/tests/php/Model/LocaleTest.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\CheckboxField;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
+use SilverStripe\Core\Config\Config;
 
 class LocaleTest extends SapphireTest
 {
@@ -120,6 +121,18 @@ class LocaleTest extends SapphireTest
         $result = Locale::getByLocale('es_US')->getBaseURL();
         $this->assertNotContains('fluent.es', $result, "Domain not used");
         $this->assertContains('/es-usa/', $result, 'URL Segment necessary for non-global default');
+    }
+
+    public function testUseFullDefaultBaseURL()
+    {
+        // Default base url shortens the default locale url base by excluding its url segment
+        $result = Locale::getDefault()->getBaseURL();
+        $this->assertNotContains('/au/', $result);
+
+        // Default base url preserves the default url segment
+        Config::inst()->set(Locale::class, 'use_full_default_base_url', true);
+        $result = Locale::getDefault()->getBaseURL();
+        $this->assertContains('/au/', $result);
     }
 
     public function testGetSiblings()

--- a/tests/php/Model/LocaleTest.yml
+++ b/tests/php/Model/LocaleTest.yml
@@ -5,7 +5,7 @@ TractorCow\Fluent\Model\Locale:
   en_AU:
     Locale: en_AU
     URLSegment: au
-    IsDefault: 1
+    IsGlobalDefault: 1
   es_ES:
     Locale: es_ES
     URLSegment: es


### PR DESCRIPTION
* Added `use_full_default_base_url` config to Locale
* Added tests to cover new default behaviour

https://github.com/tractorcow-farm/silverstripe-fluent/issues/486