### PR TITLE
BUGFIX: Display the current domain's default locale url segment in base urls

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -34,10 +34,12 @@ displayed in the default locale.
 
 ## Default locale options
 
-If you prefer to keep the prefix off from all links in the default locale, you can set the
-`TractorCow\Fluent\Extension\FluentDirectorExtension.disable_default_prefix` option via
-YML config. When this is enabled, the prefix will only be prepended to the beginning of
-links to non-default locales.
+### Disable default locale url segment prefix
+
+`TractorCow\Fluent\Extension\FluentDirectorExtension.disable_default_prefix` (default: `false`)
+
+If you prefer to keep the prefix off from all links in the default locale, you can set this option via
+YML config. When this is enabled, the prefix will only be used (prepended) in links to non-default locales.
 
 E.g.
 

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -4,6 +4,7 @@ namespace TractorCow\Fluent\Model;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
@@ -23,6 +24,7 @@ use SilverStripe\ORM\ManyManyList;
 use Symbiote\GridFieldExtensions\GridFieldAddNewInlineButton;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
+use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\State\FluentState;
 
 /**
@@ -455,8 +457,15 @@ class Locale extends DataObject
             $base = Controller::join_links($domain->Link(), $base);
         }
 
-        // Append locale urlsegment if a non-default locale
-        if (!$this->getIsDefault()) {
+        // Determine if base suffix should be appended
+        $append = true;
+        if ($this->getIsDefault()) {
+            // Apply config
+            $append = !(bool) Config::inst()->get(FluentDirectorExtension::class, 'disable_default_prefix');
+        }
+
+        if ($append) {
+            // Append locale url segment
             $base = Controller::join_links($base, $this->getURLSegment(), '/');
         }
 

--- a/tests/php/Model/LocaleTest.php
+++ b/tests/php/Model/LocaleTest.php
@@ -4,9 +4,12 @@ namespace TractorCow\Fluent\Tests\Model;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\CheckboxField;
+use TractorCow\Fluent\Extension\FluentExtension;
+use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
+use SilverStripe\Core\Config\Config;
 
 class LocaleTest extends SapphireTest
 {
@@ -108,8 +111,22 @@ class LocaleTest extends SapphireTest
         $this->assertContains('/es/', $result, 'URL segment for non-default locale is in the URL');
     }
 
-    public function testGetBaseURLOnlyContainsDomainForDefaultLocale()
+    public function testBaseURLPrefixDisabled()
     {
+        // Default base url includes the default url segment
+        $result = Locale::getDefault()->getBaseURL();
+        $this->assertContains('/au/', $result);
+
+        // Default base url shortens the default locale url base by excluding the locale's url segment
+        Config::inst()->set(FluentDirectorExtension::class, 'disable_default_prefix', true);
+        $result = Locale::getDefault()->getBaseURL();
+        $this->assertNotContains('/au/', $result);
+    }
+
+    public function testGetBaseURLOnlyContainsDomainForPrefixDisabledDefaultLocale()
+    {
+        Config::inst()->set(FluentDirectorExtension::class, 'disable_default_prefix', true);
+
         // es_US has a domain and is the default
         $result = Locale::getByLocale('es_US')->getBaseURL();
         $this->assertContains('fluent.es', $result, "Locale's domain is in the URL");

--- a/tests/php/Model/LocaleTest.yml
+++ b/tests/php/Model/LocaleTest.yml
@@ -5,7 +5,7 @@ TractorCow\Fluent\Model\Locale:
   en_AU:
     Locale: en_AU
     URLSegment: au
-    IsDefault: 1
+    IsGlobalDefault: 1
   es_ES:
     Locale: es_ES
     URLSegment: es


### PR DESCRIPTION
* Added check to locale base url generation
* Added tests to cover new default behaviour
* Docs altered

## Warning
This may be a breaking change

https://github.com/tractorcow-farm/silverstripe-fluent/issues/486