### PR TITLE
FIX: Fluent rules block other controllers from defining rules on the locale

### DIFF
--- a/src/Extension/FluentDirectorExtension.php
+++ b/src/Extension/FluentDirectorExtension.php
@@ -161,13 +161,16 @@ class FluentDirectorExtension extends Extension
      * @param array $rules Array of rules to insert before
      * @param string $key Rule to insert the new rules before
      * @param array $rule New Rules to insert
+     * @param boolean $prependIfMissing Prepend the new rules if the insert before rule cannot be found
      * @return array Resulting array of rules
      */
-    protected function insertRuleBefore(array $rules, $key, array $rule)
+    protected function insertRuleBefore(array $rules, $key, array $rule, $prependIfMissing = true)
     {
         $i = array_search($key, array_keys($rules));
         if ($i !== false) {
             return array_slice($rules, 0, $i, true) + $rule + array_slice($rules, $i, null, true);
+        } elseif ($prependIfMissing) {
+            $rules = $rule + $rules;
         }
 
         return $rules;

--- a/src/Extension/FluentDirectorExtension.php
+++ b/src/Extension/FluentDirectorExtension.php
@@ -68,14 +68,10 @@ class FluentDirectorExtension extends Extension
     public function updateRules(&$rules)
     {
         $originalRules = $rules;
-        $rules = $this->getExplicitRoutes($originalRules);
+        $fluentRules = $this->getExplicitRoutes($rules);
 
-        // Merge all other routes (maintain priority)
-        foreach ($originalRules as $key => $route) {
-            if (!isset($rules[$key])) {
-                $rules[$key] = $route;
-            }
-        }
+        // Insert Fluent Rules before the default '$URLSegment//$Action/$ID/$OtherID'
+        $rules = $this->insertRuleBefore($rules, '$URLSegment//$Action/$ID/$OtherID', $fluentRules);
 
         $request = Injector::inst()->get(HTTPRequest::class);
         if (!$request) {
@@ -158,5 +154,22 @@ class FluentDirectorExtension extends Extension
         // Decorate Director class to override controllers for a specific locale
         $this->owner->extend('updateLocalePageController', $controller, $localeObj);
         return $controller;
+    }
+
+    /**
+     * Inserts the given rule(s) before another rule
+     * @param array $rules Array of rules to insert before
+     * @param string $key Rule to insert the new rules before
+     * @param array $rule New Rules to insert
+     * @return array Resulting array of rules
+     */
+    protected function insertRuleBefore(array $rules, $key, array $rule)
+    {
+        $i = array_search($key, array_keys($rules));
+        if ($i !== false) {
+            return array_slice($rules, 0, $i, true) + $rule + array_slice($rules, $i, null, true);
+        }
+
+        return $rules;
     }
 }

--- a/tests/php/Extension/FluentDirectorExtensionTest.php
+++ b/tests/php/Extension/FluentDirectorExtensionTest.php
@@ -4,12 +4,16 @@ namespace TractorCow\Fluent\Tests\Extension;
 
 use Page;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\FunctionalTest;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Extension\FluentFilteredExtension;
 use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
+use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
+use TractorCow\Fluent\Tests\Extension\FluentDirectorExtensionTest\TestController;
 
 /**
  * Class FluentDirectorExtensionTest
@@ -60,5 +64,51 @@ class FluentDirectorExtensionTest extends FunctionalTest
 
             $this->assertContains(sprintf('<title>%s', $expectedTitle), $this->content());
         });
+    }
+
+    public function testLocalizedControllerRouting()
+    {
+        $locale = 'en_NZ';
+        FluentState::singleton()->withState(function (FluentState $state) use ($locale) {
+            $state->setLocale($locale);
+
+            $expectedTitle = sprintf('Page1 (%s)', $locale);
+
+            /** @var Page|FluentSiteTreeExtension $page */
+            $page = Page::get()->filter(['Title' => $expectedTitle])->first();
+            $this->assertNotEmpty($page);
+            $page->publishRecursive();
+        });
+
+
+        $this->get(Director::absoluteURL('nouvelle-z%C3%A9lande/TestController'));
+
+        $this->assertContains('Test Controller! en_NZ', $this->content());
+    }
+
+    protected function setUpRoutes()
+    {
+        parent::setUpRoutes();
+
+        // Add controller-name auto-routing
+        $rules = Director::config()->rules;
+
+        // Modify the rule for our test controller to include the locale parameter
+        $i = array_search('admin', array_keys($rules));
+        if ($i !== false) {
+            $rule = [
+                'nouvelle-z%C3%A9lande/TestController//$Action/$ID/$OtherID' => [
+                    'Controller' => TestController::class,
+                    'l' => 'en_NZ'
+                ]
+            ];
+
+            $rules = array_slice($rules, 0, $i, true) + $rule + array_slice($rules, $i, null, true);
+        } else {
+            throw new \Exception('Could not find "admin" url rule');
+        }
+
+        // Add controller-name auto-routing
+        Director::config()->set('rules', $rules);
     }
 }

--- a/tests/php/Extension/FluentDirectorExtensionTest/TestController.php
+++ b/tests/php/Extension/FluentDirectorExtensionTest/TestController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Extension\FluentDirectorExtensionTest;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Dev\TestOnly;
+use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\State\FluentState;
+
+class TestController extends Controller implements TestOnly
+{
+    private static $url_segment = 'TestController';
+
+    public function index()
+    {
+        return 'Test Controller! ' . FluentState::singleton()->getLocale();
+    }
+
+    public function Link($action = null)
+    {
+        return Controller::join_links('nouvelle-zélande', parent::Link($action));
+    }
+}


### PR DESCRIPTION
Fluent's rules are appended to the beginning of Director's rules list this means that the rule that handles routing to `ModelAsController` trumps all other rules in the site.

For example if we're using the slug "us" for the "en_US" locale and we want to have a controller with a rule "en/search//$Action/$ID/$OtherID" that directs to our own controller. Rather than our own controller as expected handling the request `ModelAsController` handles the request instead. This is due to the order of the rules for Fluent when they are added to the rules array in `FluentDirectorExtension`.

This pull request changes the way the rules are merged so the `RootURLController` rules and the `ModelAsController` rules appear just before the `$URLSegment//$Action/$ID/$OtherID` rule. Having the root url's at the top seems to break the model as controller rules, it could be something to do with the rule itself but I'm not sure.