### PR TITLE
BUGFIX: Fixed issue where the sort order of queries would not be maintained

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -394,7 +394,13 @@ class FluentExtension extends DataExtension
                     // Wrap sort in group to prevent dataquery messing it up
                     unset($order[$column]);
                     $order["({$localisedColumn})"] = $direction;
+                } else {
+                    unset($order[$column]);
+                    $order[$column] = $direction;
                 }
+            } else {
+                unset($order[$column]);
+                $order[$column] = $direction;
             }
         }
         $query->setOrderBy($order);

--- a/tests/php/Extension/FluentExtensionTest.php
+++ b/tests/php/Extension/FluentExtensionTest.php
@@ -12,6 +12,7 @@ use TractorCow\Fluent\State\FluentState;
 use TractorCow\Fluent\Tests\Extension\FluentExtensionTest\LocalisedAnother;
 use TractorCow\Fluent\Tests\Extension\FluentExtensionTest\LocalisedChild;
 use TractorCow\Fluent\Tests\Extension\FluentExtensionTest\LocalisedParent;
+use TractorCow\Fluent\Tests\Extension\FluentExtensionTest\MixedLocalisedSortObject;
 use TractorCow\Fluent\Tests\Extension\FluentExtensionTest\UnlocalisedChild;
 use TractorCow\Fluent\Tests\Extension\Stub\FluentStubObject;
 
@@ -23,6 +24,7 @@ class FluentExtensionTest extends SapphireTest
         LocalisedAnother::class,
         LocalisedChild::class,
         LocalisedParent::class,
+        MixedLocalisedSortObject::class,
         UnlocalisedChild::class,
     ];
 
@@ -156,6 +158,39 @@ class FluentExtensionTest extends SapphireTest
             $this->assertTrue(
                 $this->hasLocalisedRecord($record3, 'es_ES'),
                 'Record Locale is set to current locale when writing new records'
+            );
+        });
+    }
+
+    public function testLocalisedMixSorting()
+    {
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState->setLocale('en_US');
+
+            // Sort by the NonLocalisedSort field first then the LocalisedField second both in ascending order
+            // so the result will be opposite if the order of the columns is not maintained
+            $objects=MixedLocalisedSortObject::get()->sort(
+                '"FluentExtensionTest_MixedLocalisedSortObject"."LocalizedSort", '.
+                '"FluentExtensionTest_MixedLocalisedSortObject"."NonLocalizedSort", '.
+                '"FluentExtensionTest_MixedLocalisedSortObject"."Title"'
+            );
+
+            // Make sure Item A is first
+            $this->assertEquals(
+                'Item A',
+                $objects->offsetGet(0)->Title
+            );
+
+            // Make sure Item B is second
+            $this->assertEquals(
+                'Item B',
+                $objects->offsetGet(1)->Title
+            );
+
+            // Make sure Item C is third
+            $this->assertEquals(
+                'Item C',
+                $objects->offsetGet(2)->Title
             );
         });
     }

--- a/tests/php/Extension/FluentExtensionTest.yml
+++ b/tests/php/Extension/FluentExtensionTest.yml
@@ -61,3 +61,34 @@ FluentExtensionTest_LocalisedParent_Localised:
     Title: Rennen
     Details: Gehe zur Bibliothek
     Locale: de_DE
+
+TractorCow\Fluent\Tests\Extension\FluentExtensionTest\MixedLocalisedSortObject:
+  record_a:
+    Title: Item A
+    LocalizedSort: 1
+    NonLocalizedSort: 3
+  record_b:
+    Title: Item B
+    LocalizedSort: 2
+    NonLocalizedSort: 2
+  record_c:
+    Title: Item C
+    LocalizedSort: 3
+    NonLocalizedSort: 1
+
+FluentExtensionTest_MixedLocalisedSortObject_Localised:
+  record_a:
+    RecordID: =>TractorCow\Fluent\Tests\Extension\FluentExtensionTest\MixedLocalisedSortObject.record_a
+    Title: Item A
+    LocalizedSort: 1
+    Locale: en_US
+  record_b:
+    RecordID: =>TractorCow\Fluent\Tests\Extension\FluentExtensionTest\MixedLocalisedSortObject.record_b
+    Title: Item B
+    LocalizedSort: 2
+    Locale: en_US
+  record_c:
+    RecordID: =>TractorCow\Fluent\Tests\Extension\FluentExtensionTest\MixedLocalisedSortObject.record_c
+    Title: Item C
+    LocalizedSort: 3
+    Locale: en_US

--- a/tests/php/Extension/FluentExtensionTest/MixedLocalisedSortObject.php
+++ b/tests/php/Extension/FluentExtensionTest/MixedLocalisedSortObject.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Extension\FluentExtensionTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use TractorCow\Fluent\Extension\FluentExtension;
+
+class MixedLocalisedSortObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'FluentExtensionTest_MixedLocalisedSortObject';
+
+    private static $translate = [
+        'LocalizedSort',
+        'Title',
+    ];
+
+    private static $extensions = [
+        'FluentExtension' => FluentExtension::class,
+    ];
+
+    private static $field_exclude = [
+        'NonLocalizedSort',
+    ];
+
+    private static $field_include = [
+        'LocalizedSort',
+    ];
+
+    private static $data_include = [
+        'Varchar',
+    ];
+
+    private static $db = [
+        'Title' => 'Varchar',
+        'NonLocalizedSort' => 'Int',
+        'LocalizedSort' => 'Int',
+    ];
+}


### PR DESCRIPTION
This pull request fixes the issue mentioned in #507 in short if the sort columns of a query are a mix of localized and non-localized fields the order will become non-localized fields first then the localized fields. This is caused by how the fields are removed and re-added to the associative array not factoring in the non-localized fields keeping them in order at the start of the query.