### PR TITLE
FIX Fluent badge labels in the CMS are now able to be modified by extensions

### DIFF
--- a/src/Extension/FluentBadgeExtension.php
+++ b/src/Extension/FluentBadgeExtension.php
@@ -71,7 +71,7 @@ class FluentBadgeExtension extends Extension
     /**
      * Given a record with Fluent enabled, return a badge that represents the state of it in the current locale
      *
-     * @param DataObject $record
+     * @param DataObject&FluentVersionedExtension $record
      * @return DBField
      */
     public function getBadge(DataObject $record)
@@ -104,7 +104,7 @@ class FluentBadgeExtension extends Extension
                 '<span class="%s" title="%s">%s</span>',
                 implode(' ', $badgeClasses),
                 $tooltip,
-                $record->getSourceLocale()->getLocaleSuffix()
+                $record->getSourceLocale()->getBadgeLabel()
             )
         );
     }

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -158,6 +158,27 @@ class Locale extends DataObject
     }
 
     /**
+     * Returns the label to display for Fluent badges in the CMS. By default this is the locale suffix, e.g. 'US'
+     * or 'NZ', but can be configured with extensions.
+     *
+     * For example, you may want to display the full locale badge:
+     * <code>
+     * public function updateBadgeLabel(&$badgeLabel)
+     * {
+     *     $badgeLabel = $this->owner->Locale;
+     * }
+     * </code>
+     *
+     * @return string
+     */
+    public function getBadgeLabel()
+    {
+        $badgeLabel = $this->getLocaleSuffix();
+        $this->extend('updateBadgeLabel', $badgeLabel);
+        return (string) $badgeLabel;
+    }
+
+    /**
      * Get URLSegment for this locale
      *
      * @return string


### PR DESCRIPTION
This should've been extensible from the beginning, which is why I'm calling this a bug fix.

Fixes #389