### PR TITLE
FIX: Fixed issue where order by would not be re-written properly if the sort column is not quoted

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -382,6 +382,10 @@ class FluentExtension extends DataExtension
                 $localisedColumn = $column;
                 // Fix non-fully-qualified name
                 if (!$fqn) {
+                    if (strpos($localisedColumn, '"') === false) {
+                        $localisedColumn = '"' . $localisedColumn . '"';
+                    }
+                    
                     $localisedColumn = str_replace(
                         "\"{$field}\"",
                         "\"{$table}\".\"{$field}\"",
@@ -985,6 +989,18 @@ class FluentExtension extends DataExtension
 
         // Check sole "field" without table specifier ("name" without leading or trailing '.')
         if (preg_match('/(?<![.])"(?<field>\w+)"(?![.])/i', $sql, $matches)) {
+            $field = $matches['field'];
+
+            // Check if this field is in any of the tables, and just pick any that match
+            foreach ($tables as $table => $fields) {
+                if (in_array($field, $fields)) {
+                    return [$table, $field, false];
+                }
+            }
+        }
+
+        // Check sole "field" without table specifier ("name" without leading or trailing '.' and without quotes)
+        if (preg_match('/(?<![.])(?<field>\w+)(?![.])/i', $sql, $matches)) {
             $field = $matches['field'];
 
             // Check if this field is in any of the tables, and just pick any that match


### PR DESCRIPTION
This pull request addresses an issue where the sort column would not be properly re-written when the sort column is not double quoted and is a localized column. On MySQL 5.7.5+ this causes the query to crash due to `ONLY_FULL_GROUP_BY` being enabled in `ANSI` mode and by default.

For example given the below object, attempting to do a `MyObject::get()` would result in the query's select being rewritten accounting for the localized `Title` column. However the order by is not re-written properly to account for it.

```php
class MyObject extends DataObject
{
    private static $db = [
        'Title' => 'Varchar(50)',
    ];
    
    private static $field_include = [
        'Title',
    ];
    
    private static $extensions = [
        FluentExtension::class,
    ];
    
    private static $default_sort = 'Title';
}
```

I'm not 100% confident in this fixing it fully as my site's tests erroring in one specific case on MySQL 5.7.25 due to only full group by but the rest of the cases that were erroring out do work now.