### PR TITLE
FIX Fluent now respects existing base URL prefixes in URL segment fields when no fluent domain exists

### DIFF
--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -244,9 +244,9 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
             return $this;
         }
 
-        // Mock frontend and get link to parent object / page
-        $baseURL = FluentState::singleton()
-            ->withState(function (FluentState $tempState) {
+        // Mock frontend and set link to parent object / page
+        FluentState::singleton()
+            ->withState(function (FluentState $tempState) use ($segmentField) {
                 $tempState->setIsDomainMode(true);
                 $tempState->setIsFrontend(true);
 
@@ -264,15 +264,14 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
                 if ($domain) {
                     $parentBase = Controller::join_links($domain->Link(), Director::baseURL());
                 } else {
-                    $parentBase = Director::absoluteBaseURL();
+                    // Use any existing pre-configured base URL prefix for the field
+                    $parentBase = $segmentField->getURLPrefix();
                 }
 
                 // Join base / relative links
-                return Controller::join_links($parentBase, $parentRelative);
+                $segmentField->setURLPrefix(Controller::join_links($parentBase, $parentRelative));
             });
 
-
-        $segmentField->setURLPrefix($baseURL);
         return $this;
     }
 

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -316,7 +316,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
                 $fields = $this->objFromFixture(Page::class, $fixture)->getCMSFields();
 
                 /** @var SiteTreeURLSegmentField $segmentField */
-                $segmentField = $fields->fieldByName('Root.Main.URLSegment');
+                $segmentField = $fields->dataFieldByName('URLSegment');
                 $this->assertInstanceOf(SiteTreeURLSegmentField::class, $segmentField);
 
                 $this->assertSame($expected, $segmentField->getURLPrefix());


### PR DESCRIPTION
Fluent sets the URLSegment field's URLPrefix to be the base domain plus the parent page path including the current locale. When no fluent domains are configured, this defaulted to `Director::absoluteBaseURL()`. This was a bit heavy handed, since it doesn't consider any previous modifications to `SiteTreeURLSegmentField::setURLPrefix()` (e.g. in subsites, where it sets the subsite domain).

I've changed this to use the existing URL prefix instead.

There will still be conflicts if you use subsite domains and fluent domains at the same time, since they represent the same functionality, but that can be documented.

Fixes https://github.com/silverstripe/silverstripe-subsites/issues/416