### PR TITLE
FIX Support archive query selecting with conditional subselects

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -146,6 +146,43 @@ class FluentVersionedExtension extends FluentExtension
     }
 
     /**
+     * Hook into Versioned::prepareMaxVersionSubSelect - ensure that max version returned by the subquery are limited to
+     * the current locale
+     *
+     * @param SQLSelect $subSelect
+     * @param DataQuery $baseQuery
+     * @param $isCondition
+     */
+    public function augmentMaxVersionSubSelect(SQLSelect $subSelect, DataQuery $baseQuery, $isCondition)
+    {
+        if (!$isCondition) {
+            return;
+        }
+
+        $locale = $this->getDataQueryLocale($baseQuery);
+
+        if (!$locale) {
+            return;
+        }
+
+        $fromTables = $subSelect->getFrom();
+        $baseTable = preg_replace('/' . preg_quote(self::SUFFIX_VERSIONS) . '$/', '', trim(reset($fromTables), '"'));
+        $tableAlias = key($fromTables);
+        $localisedTable = $this->getLocalisedTable($baseTable) . self::SUFFIX_VERSIONS;
+
+        $joinCondition = <<<SQL
+"$tableAlias"."RecordID" = "$localisedTable"."RecordID" AND "$tableAlias"."Version" = "$localisedTable"."Version"
+SQL;
+
+        $subSelect->addLeftJoin(
+            $localisedTable,
+            $joinCondition
+        );
+
+        $subSelect->addWhere("\"$localisedTable\".\"Locale\" = '{$locale->getLocale()}'");
+    }
+
+    /**
      * Rewrite all joined tables
      *
      * @param SQLSelect $query


### PR DESCRIPTION
See (and wait for merge on) silverstripe/silverstripe-versioned#225. This PR ensures that max versions returned by the subquery are limited to the current locale.