### PR TITLE
Add `$SelectedLanguage` template variable to fluent

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -997,4 +997,14 @@ class FluentExtension extends DataExtension
 
         return [null, null, false];
     }
+
+    /**
+     * Returns the selected language
+     *
+     * @return ArrayData
+     */
+    public function getSelectedLanguage()
+    {
+        return $this->LocaleInformation(FluentState::singleton()->getLocale());
+    }
 }


### PR DESCRIPTION
Already exists in `cwp/cwp` but it should be available in `FluentExtension`