### PR TITLE
ENHANCEMENT Configurable policies for handling the deletion of objects

### DIFF
--- a/_config/delete.yml
+++ b/_config/delete.yml
@@ -1,0 +1,6 @@
+---
+Name: fluentdelete
+---
+SilverStripe\Core\Injector\Injector:
+  TractorCow\Fluent\Model\Delete\DeletePolicy:
+    factory: \TractorCow\Fluent\Model\Delete\DeletePolicyFactory

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -565,6 +565,18 @@ class FluentExtension extends DataExtension
         }
         return $localisedTable;
     }
+    
+    /**
+     * Public accessor for getDeleteTableTarget
+     *
+     * @param string $tableName
+     * @param string $locale
+     * @return string
+     */
+    public function deleteTableTarget($tableName, $locale = '')
+    {
+        return $this->getDeleteTableTarget($tableName, $locale);
+    }
 
     /**
      * Get real table name for deleting records (Note: Must have all table replacements applied)
@@ -573,7 +585,7 @@ class FluentExtension extends DataExtension
      * @param string $locale If passed, this is the locale we wish to delete in. If empty this is the root table
      * @return string
      */
-    public function getDeleteTableTarget($tableName, $locale = '')
+    protected function getDeleteTableTarget($tableName, $locale = '')
     {
         if (!$locale) {
             return $tableName;

--- a/src/Extension/FluentFilteredExtension.php
+++ b/src/Extension/FluentFilteredExtension.php
@@ -2,20 +2,17 @@
 
 namespace TractorCow\Fluent\Extension;
 
+use SilverStripe\Forms\CheckboxSetField;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\GridField\GridField;
-use SilverStripe\Forms\GridField\GridFieldAddNewButton;
-use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
-use SilverStripe\Forms\Tab;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\Versioned\Versioned;
+use TractorCow\Fluent\Model\Delete\UsesDeletePolicy;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
-use SilverStripe\Forms\CheckboxSetField;
 
 /**
  * @property FluentFilteredExtension|DataObject $owner
@@ -23,6 +20,11 @@ use SilverStripe\Forms\CheckboxSetField;
  */
 class FluentFilteredExtension extends DataExtension
 {
+    /**
+     * Deletions are managed via DeletePolicy
+     */
+    use UsesDeletePolicy;
+
     /**
      * The table suffix that will be applied to a DataObject's base table.
      */
@@ -46,14 +48,14 @@ class FluentFilteredExtension extends DataExtension
             'Root.FilteredLocales',
             CheckboxSetField::create(
                 'FilteredLocales',
-                _t(__CLASS__.'.FILTERED_LOCALES', 'Display in the following locales'),
+                _t(__CLASS__ . '.FILTERED_LOCALES', 'Display in the following locales'),
                 $locales
             )
         );
 
         $fields
             ->fieldByName('Root.FilteredLocales')
-            ->setTitle(_t(__CLASS__.'.TAB_LOCALES', 'Locales'));
+            ->setTitle(_t(__CLASS__ . '.TAB_LOCALES', 'Locales'));
     }
 
     /**
@@ -77,7 +79,7 @@ class FluentFilteredExtension extends DataExtension
 
         // Add new status flag for "not visible".
         $flags['fluentfiltered'] = [
-            'text' => null,
+            'text'  => null,
             'title' => _t(__CLASS__ . '.LOCALEFILTEREDHELP', 'This page is not visible in this locale')
         ];
     }
@@ -100,7 +102,7 @@ class FluentFilteredExtension extends DataExtension
     }
 
     /**
-     * @param SQLSelect $query
+     * @param SQLSelect      $query
      * @param DataQuery|null $dataQuery
      */
     public function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null)

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -254,7 +254,7 @@ class FluentVersionedExtension extends FluentExtension
      * @param string $locale
      * @return string
      */
-    protected function getDeleteTableTarget($tableName, $locale = '')
+    public function getDeleteTableTarget($tableName, $locale = '')
     {
         // Rewrite to _Live when deleting from live / unpublishing
         $table = parent::getDeleteTableTarget($tableName, $locale);

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -47,7 +47,7 @@ class FluentVersionedExtension extends FluentExtension
      */
     protected $defaultVersionsIndexes = [
         'Fluent_Record' => [
-            'type' => 'unique',
+            'type'    => 'unique',
             'columns' => [
                 'RecordID',
                 'Locale',
@@ -149,8 +149,8 @@ class FluentVersionedExtension extends FluentExtension
      * Rewrite all joined tables
      *
      * @param SQLSelect $query
-     * @param array $tables
-     * @param Locale $locale
+     * @param array     $tables
+     * @param Locale    $locale
      */
     protected function rewriteVersionedTables(SQLSelect $query, array $tables, Locale $locale)
     {
@@ -168,8 +168,8 @@ class FluentVersionedExtension extends FluentExtension
      * Update all joins to include Version as well as Locale / Record
      *
      * @param SQLSelect $query
-     * @param string $tableName
-     * @param Locale $locale
+     * @param string    $tableName
+     * @param Locale    $locale
      */
     protected function addLocaleFallbackChain(SQLSelect $query, $tableName, Locale $locale)
     {
@@ -193,7 +193,7 @@ class FluentVersionedExtension extends FluentExtension
      * Rename all localised tables to the "live" equivalent name (note: alias remains unchanged)
      *
      * @param SQLSelect $query
-     * @param array $tables
+     * @param array     $tables
      */
     protected function renameLocalisedTables(SQLSelect $query, array $tables)
     {
@@ -254,7 +254,7 @@ class FluentVersionedExtension extends FluentExtension
      * @param string $locale
      * @return string
      */
-    public function getDeleteTableTarget($tableName, $locale = '')
+    protected function getDeleteTableTarget($tableName, $locale = '')
     {
         // Rewrite to _Live when deleting from live / unpublishing
         $table = parent::getDeleteTableTarget($tableName, $locale);
@@ -300,7 +300,7 @@ class FluentVersionedExtension extends FluentExtension
     /**
      * Check to see whether or not a record exists for a specific Locale in a specific stage.
      *
-     * @param string $stage Version stage
+     * @param string $stage  Version stage
      * @param string $locale Locale to check. Defaults to current locale.
      * @return bool
      */
@@ -325,7 +325,7 @@ class FluentVersionedExtension extends FluentExtension
 
         // Check for a cached item in the full list of all objects. These are populated optimistically.
         if (isset(static::$idsInLocaleCache[$locale][$table][$this->owner->ID])) {
-            return (bool) static::$idsInLocaleCache[$locale][$table][$this->owner->ID];
+            return (bool)static::$idsInLocaleCache[$locale][$table][$this->owner->ID];
         }
 
         if (!empty(static::$idsInLocaleCache[$locale][$table]['_complete'])) {
@@ -343,16 +343,16 @@ class FluentVersionedExtension extends FluentExtension
      *
      * @param string $locale
      * @param string $table
-     * @param int $id
+     * @param int    $id
      * @return bool
      */
     protected function findRecordInLocale($locale, $table, $id)
     {
         $query = SQLSelect::create('"ID"');
-        $query->addFrom('"'. $table . '"');
+        $query->addFrom('"' . $table . '"');
         $query->addWhere([
             '"RecordID"' => $id,
-            '"Locale"' => $locale,
+            '"Locale"'   => $locale,
         ]);
 
         return $query->firstRow()->execute()->value() !== null;
@@ -370,8 +370,8 @@ class FluentVersionedExtension extends FluentExtension
      * Hook into {@link Hierarchy::prepopulateTreeDataCache}.
      *
      * @param DataList|array $recordList The list of records to prepopulate caches for. Null for all records.
-     * @param array $options A map of hints about what should be cached. "numChildrenMethod" and
-     *                       "childrenMethod" are allowed keys.
+     * @param array          $options    A map of hints about what should be cached. "numChildrenMethod" and
+     *                                   "childrenMethod" are allowed keys.
      */
     public function onPrepopulateTreeDataCache($recordList = null, array $options = [])
     {
@@ -393,8 +393,8 @@ class FluentVersionedExtension extends FluentExtension
      *
      * @param string $locale
      * @param string $dataObjectClass
-     * @param bool $populateLive
-     * @param bool $populateDraft
+     * @param bool   $populateLive
+     * @param bool   $populateDraft
      */
     public static function prepoulateIdsInLocale($locale, $dataObjectClass, $populateLive = true, $populateDraft = true)
     {

--- a/src/Model/Delete/DeleteFilterPolicy.php
+++ b/src/Model/Delete/DeleteFilterPolicy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TractorCow\Fluent\Model\Delete;
+
+use InvalidArgumentException;
+use SilverStripe\ORM\DataObject;
+use TractorCow\Fluent\Extension\FluentFilteredExtension;
+use TractorCow\Fluent\Model\Locale;
+
+/**
+ * A policy that deletes the filtered rows.
+ *
+ * Requires {@see FluentFilteredExtension} on the object
+ */
+class DeleteFilterPolicy implements DeletePolicy
+{
+
+    /**
+     * @param DataObject|FluentFilteredExtension $record
+     * @return bool
+     */
+    public function delete(DataObject $record)
+    {
+        // Ensure a locale exists
+        $locale = Locale::getCurrentLocale();
+        if (!$locale) {
+            return false;
+        }
+        if (!$record->hasExtension(FluentFilteredExtension::class)) {
+            throw new InvalidArgumentException("This policy only works with filtered objects (FluentFilteredExtension)");
+        }
+
+        // Remove filtered locale
+        $record->FilteredLocales()->removeByID($locale->ID);
+
+        // Check if this record is visible in any other locale
+        return $record->FilteredLocales()->count() > 0;
+    }
+}

--- a/src/Model/Delete/DeleteFilterPolicy.php
+++ b/src/Model/Delete/DeleteFilterPolicy.php
@@ -17,7 +17,11 @@ class DeleteFilterPolicy implements DeletePolicy
 
     /**
      * @param DataObject|FluentFilteredExtension $record
-     * @return bool
+     * @return bool Determines if any dependent objects block upstream deletion (e.g. db / model constraints)
+     *              If this returns true, then there are additional conditions that must be satisfied before
+     *              upstream relational constraints are safe to delete.
+     *              If this returns true, then all downstream entities are reported purged, and upstream
+     *              relational constraints can be deleted.
      */
     public function delete(DataObject $record)
     {

--- a/src/Model/Delete/DeleteLocalisationPolicy.php
+++ b/src/Model/Delete/DeleteLocalisationPolicy.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace TractorCow\Fluent\Model\Delete;
+
+use InvalidArgumentException;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLDelete;
+use SilverStripe\ORM\Queries\SQLSelect;
+use TractorCow\Fluent\Extension\FluentExtension;
+use TractorCow\Fluent\Model\Locale;
+
+/**
+ * A policy that deletes all localisations for a record
+ *
+ * Requires that the object has {@see FluentExtension}
+ */
+class DeleteLocalisationPolicy implements DeletePolicy
+{
+    /**
+     * @param DataObject|FluentExtension $record
+     * @return bool
+     */
+    public function delete(DataObject $record)
+    {
+        // Ensure a locale exists
+        $locale = Locale::getCurrentLocale();
+        if (!$locale) {
+            return false;
+        }
+        if (!$record->hasExtension(FluentExtension::class)) {
+            throw new InvalidArgumentException("This policy only works with localised objects (FluentExtension)");
+        }
+
+        // Delete localisations for each level of hierarchy
+        $localisedTables = $record->getLocalisedTables();
+        $classes = ClassInfo::ancestry($record, true);
+        foreach ($classes as $class) {
+            // Check main table name
+            $table = DataObject::getSchema()->tableName($class);
+
+            // Skip if table isn't localised
+            if (!isset($localisedTables[$table])) {
+                continue;
+            }
+
+            // Remove _Localised record
+            $localisedTable = $record->getDeleteTableTarget($table, $locale);
+            $localisedDelete = SQLDelete::create(
+                "\"{$localisedTable}\"",
+                [
+                    '"Locale"'   => $locale->Locale,
+                    '"RecordID"' => $record->ID,
+                ]
+            );
+            $localisedDelete->execute();
+        }
+
+        // Check if this record has localisations for any other locale
+        return $this->checkIfBlocked($record, $locale);
+    }
+
+    /**
+     * Determine if this object has other localisations blocking deletion
+     *
+     * @param DataObject|FluentExtension $record
+     * @param Locale                     $locale
+     * @return bool
+     */
+    protected function checkIfBlocked(DataObject $record, Locale $locale)
+    {
+        $otherLocales = Locale::getCached()
+            ->exclude('ID', $locale->ID)
+            ->column('Locale');
+        if (empty($otherLocales)) {
+            // No locales; Nothing to block
+            return false;
+        }
+
+        // Check if any localisations yet remain for this record (any locale)
+        $localisedBaseTable = $record->getDeleteTableTarget($record->baseTable(), $locale);
+        $localePlaceholders = DB::placeholders($otherLocales);
+        $blockedQuery = SQLSelect::create()
+            ->setSelect('COUNT ("ID")')
+            ->setFrom("\"{$localisedBaseTable}\"")
+            ->setWhere([
+                "\"Locale\" IN ($localePlaceholders)" => $otherLocales,
+                "\"RecordID\""                        => $record->ID,
+            ]);
+
+        // Any localisations exist for this record
+        return $blockedQuery->execute()->value() > 0;
+    }
+}

--- a/src/Model/Delete/DeleteLocalisationPolicy.php
+++ b/src/Model/Delete/DeleteLocalisationPolicy.php
@@ -20,7 +20,11 @@ class DeleteLocalisationPolicy implements DeletePolicy
 {
     /**
      * @param DataObject|FluentExtension $record
-     * @return bool
+     * @return bool Determines if any dependent objects block upstream deletion (e.g. db / model constraints)
+     *              If this returns true, then there are additional conditions that must be satisfied before
+     *              upstream relational constraints are safe to delete.
+     *              If this returns true, then all downstream entities are reported purged, and upstream
+     *              relational constraints can be deleted.
      */
     public function delete(DataObject $record)
     {
@@ -46,7 +50,7 @@ class DeleteLocalisationPolicy implements DeletePolicy
             }
 
             // Remove _Localised record
-            $localisedTable = $record->getDeleteTableTarget($table, $locale);
+            $localisedTable = $record->deleteTableTarget($table, $locale);
             $localisedDelete = SQLDelete::create(
                 "\"{$localisedTable}\"",
                 [
@@ -79,7 +83,7 @@ class DeleteLocalisationPolicy implements DeletePolicy
         }
 
         // Check if any localisations yet remain for this record (any locale)
-        $localisedBaseTable = $record->getDeleteTableTarget($record->baseTable(), $locale);
+        $localisedBaseTable = $record->deleteTableTarget($record->baseTable(), $locale);
         $localePlaceholders = DB::placeholders($otherLocales);
         $blockedQuery = SQLSelect::create()
             ->setSelect('COUNT ("ID")')

--- a/src/Model/Delete/DeletePolicy.php
+++ b/src/Model/Delete/DeletePolicy.php
@@ -9,6 +9,10 @@ interface DeletePolicy
     /**
      * @param DataObject $record
      * @return bool Determines if any dependent objects block upstream deletion (e.g. db / model constraints)
+     *              If this returns true, then there are additional conditions that must be satisfied before
+     *              upstream relational constraints are safe to delete.
+     *              If this returns true, then all downstream entities are reported purged, and upstream
+     *              relational constraints can be deleted.
      */
     public function delete(DataObject $record);
 }

--- a/src/Model/Delete/DeletePolicy.php
+++ b/src/Model/Delete/DeletePolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TractorCow\Fluent\Model\Delete;
+
+use SilverStripe\ORM\DataObject;
+
+interface DeletePolicy
+{
+    /**
+     * @param DataObject $record
+     * @return bool Determines if any dependent objects block upstream deletion (e.g. db / model constraints)
+     */
+    public function delete(DataObject $record);
+}

--- a/src/Model/Delete/DeletePolicyFactory.php
+++ b/src/Model/Delete/DeletePolicyFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace TractorCow\Fluent\Model\Delete;
+
+use InvalidArgumentException;
+use SilverStripe\Core\Injector\Factory;
+use SilverStripe\ORM\DataObject;
+use TractorCow\Fluent\Extension\FluentExtension;
+use TractorCow\Fluent\Extension\FluentFilteredExtension;
+
+/**
+ * Generate a delete policy for a class
+ */
+class DeletePolicyFactory implements Factory
+{
+    /**
+     * Creates a new service instance.
+     *
+     * @param string $service The class name of the service.
+     * @param array  $params  The constructor parameters.
+     * @return DeletePolicy The created service instances.
+     */
+    public function create($service, array $params = [])
+    {
+        /** @var DataObject $object */
+        $object = reset($params);
+        if (!$object) {
+            throw new InvalidArgumentException("Missing target argument required");
+        }
+        $dependantPolicies = [];
+
+        // Fluent extension requires rows in current locale to be removed
+        if ($object->hasExtension(FluentExtension::class)) {
+            $dependantPolicies[] = new DeleteLocalisationPolicy();
+        }
+
+        // Filtered extension requires mapping table to locale to be removed
+        if ($object->hasExtension(FluentFilteredExtension::class)) {
+            $dependantPolicies[] = new DeleteFilterPolicy();
+        }
+
+        // Build policy
+        $policy = new DeleteRecordPolicy();
+        $policy->setDependantPolicies($dependantPolicies);
+        return $policy;
+    }
+}

--- a/src/Model/Delete/DeleteRecordPolicy.php
+++ b/src/Model/Delete/DeleteRecordPolicy.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace TractorCow\Fluent\Model\Delete;
+
+use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Queries\SQLDelete;
+
+/**
+ * A policy that deletes the root record
+ */
+class DeleteRecordPolicy implements DeletePolicy
+{
+    /**
+     * List of dependant policies
+     *
+     * @var DeletePolicy[]
+     */
+    protected $dependantPolicies = [];
+
+    /**
+     * @return DeletePolicy[]
+     */
+    public function getDependantPolicies()
+    {
+        return $this->dependantPolicies;
+    }
+
+    /**
+     * @param DeletePolicy[] $dependantPolicies
+     * @return $this
+     */
+    public function setDependantPolicies($dependantPolicies)
+    {
+        $this->dependantPolicies = $dependantPolicies;
+        return $this;
+    }
+
+    /**
+     * @param DataObject $record
+     * @return bool
+     */
+    public function delete(DataObject $record)
+    {
+        $blocked = false;
+        foreach ($this->getDependantPolicies() as $filter) {
+            $blocked = $filter->delete($record) || $blocked;
+        }
+
+        // Blocked by upstream policy
+        if ($blocked) {
+            return true;
+        }
+
+        // Delete base record
+        $this->deleteBaseRecord($record);
+        return false;
+    }
+
+    /**
+     * Do base record deletion
+     *
+     * @param DataObject $record
+     */
+    protected function deleteBaseRecord(DataObject $record)
+    {
+        // Copy DataObject::delete() here for now
+        $srcQuery = DataList::create(get_class($record))
+            ->filter('ID', $record->ID)
+            ->dataQuery()
+            ->query();
+        $queriedTables = $srcQuery->queriedTables();
+        foreach ($queriedTables as $table) {
+            $delete = SQLDelete::create("\"{$table}\"", array('"ID"' => $record->ID));
+            $delete->execute();
+        }
+    }
+}

--- a/src/Model/Delete/DeleteRecordPolicy.php
+++ b/src/Model/Delete/DeleteRecordPolicy.php
@@ -38,7 +38,11 @@ class DeleteRecordPolicy implements DeletePolicy
 
     /**
      * @param DataObject $record
-     * @return bool
+     * @return bool Determines if any dependent objects block upstream deletion (e.g. db / model constraints)
+     *              If this returns true, then there are additional conditions that must be satisfied before
+     *              upstream relational constraints are safe to delete.
+     *              If this returns true, then all downstream entities are reported purged, and upstream
+     *              relational constraints can be deleted.
      */
     public function delete(DataObject $record)
     {

--- a/src/Model/Delete/UsesDeletePolicy.php
+++ b/src/Model/Delete/UsesDeletePolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace TractorCow\Fluent\Model\Delete;
+
+use SilverStripe\Core\Injector\Injector;
+use TractorCow\Fluent\Model\Locale;
+
+/**
+ * @property $owner DataObject
+ */
+trait UsesDeletePolicy
+{
+    /**
+     * Override delete behaviour.
+     * Hooks into {@see DataObject::delete()}
+     *
+     * @param array $queriedTables
+     */
+    public function updateDeleteTables(&$queriedTables)
+    {
+        // Ensure a locale exists
+        $locale = Locale::getCurrentLocale();
+        if (!$locale) {
+            return;
+        }
+
+        // Solve extension race condition; first extension resets queried tables and defers to delete policy
+        if (empty($queriedTables)) {
+            return;
+        }
+        $queriedTables = [];
+
+        /** @var DeletePolicy $policy */
+        $policy = Injector::inst()->create(DeletePolicy::class, $this->owner);
+        $policy->delete($this->owner);
+    }
+}

--- a/tests/php/Model/Delete/DeleteRecordPolicyTest.php
+++ b/tests/php/Model/Delete/DeleteRecordPolicyTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Model\Delete;
+
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\ValidationException;
+use TractorCow\Fluent\Model\Delete\DeletePolicy;
+use TractorCow\Fluent\Model\Delete\DeleteRecordPolicy;
+use TractorCow\Fluent\Model\Domain;
+use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\State\FluentState;
+use TractorCow\Fluent\Tests\Model\Delete\Fixtures\FilteredRecord;
+use TractorCow\Fluent\Tests\Model\Delete\Fixtures\LocalisedRecord;
+use TractorCow\Fluent\Tests\Model\Delete\Fixtures\Record;
+
+class DeleteRecordPolicyTest extends SapphireTest
+{
+    protected static $fixture_file = '../LocaleTest.yml';
+
+    protected static $extra_dataobjects = [
+        Record::class,
+        LocalisedRecord::class,
+        FilteredRecord::class,
+    ];
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // Clear cache
+        Locale::clearCached();
+        Domain::clearCached();
+
+        // Set default
+        FluentState::singleton()
+            ->setLocale('es_US')
+            ->setIsDomainMode(false);
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function testDelete()
+    {
+        $record = new Record();
+        $record->Title = 'OK';
+        $record->write();
+
+        $this->assertEquals(
+            1,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_Record"')->value()
+        );
+
+        /** @var DeleteRecordPolicy $policy */
+        $policy = Injector::inst()->create(DeletePolicy::class, $record);
+        $this->assertInstanceOf(DeleteRecordPolicy::class, $policy);
+        $this->assertEmpty($policy->getDependantPolicies());
+
+        // Delete
+        $blocked = $policy->delete($record);
+
+        // Item is deleted
+        $this->assertEquals(
+            0,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_Record"')->value()
+        );
+        $this->assertFalse($blocked);
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function testDeleteLocalisedRecords()
+    {
+        // Write in en-US
+        $record = new LocalisedRecord();
+        $record->Title = 'us spanish content';
+        $record->write();
+        $recordID = $record->ID;
+
+        // Write in en-nz
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_NZ');
+            $record = LocalisedRecord::get()->byID($recordID);
+            $record->Title = 'nz content';
+            $record->write();
+        });
+
+        // We should have 1 base record, 2 localised records
+        $this->assertEquals(
+            2,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_LocalisedRecord_Localised"')->value()
+        );
+        $this->assertEquals(
+            1,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_LocalisedRecord"')->value()
+        );
+
+        // Delete in base locale should reduce a _Localised count
+        $record->delete();
+        $this->assertEquals(
+            1,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_LocalisedRecord_Localised"')->value()
+        );
+        $this->assertEquals(
+            1,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_LocalisedRecord"')->value()
+        );
+
+        // Delete in en-nz should remove all _Localised and base
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_NZ');
+            $record = LocalisedRecord::get()->byID($recordID);
+            $record->delete();
+        });
+
+        $this->assertEquals(
+            0,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_LocalisedRecord_Localised"')->value()
+        );
+        $this->assertEquals(
+            0,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_LocalisedRecord"')->value()
+        );
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function testDeleteFilteredRecords()
+    {
+        // Add to 2 locales
+        $record = new FilteredRecord();
+        $record->Title = 'Content';
+        $record->write();
+        $record->FilteredLocales()->add(Locale::get()->find('Locale', 'en_NZ'));
+        $record->FilteredLocales()->add(Locale::get()->find('Locale', 'es_US'));
+        $recordID = $record->ID;
+
+        // mapping table has 2 records
+        $this->assertEquals(
+            2,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_FilteredRecord_FilteredLocales"')->value()
+        );
+
+        // Deleting in current locale (es_US) should reduce mapping table to 1
+        $record->delete();
+
+        // We should have 1 base record, 2 localised records
+        $this->assertEquals(
+            1,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_FilteredRecord_FilteredLocales"')->value()
+        );
+        $this->assertEquals(
+            1,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_FilteredRecord"')->value()
+        );
+
+        // Delete in en_nz should remove the last filteredlocale mapping table, and also the base record
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_NZ');
+            $record = FilteredRecord::get()->byID($recordID);
+            $record->delete();
+        });
+        $this->assertEquals(
+            0,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_FilteredRecord_FilteredLocales"')->value()
+        );
+        $this->assertEquals(
+            0,
+            DB::query('SELECT COUNT("ID") FROM "FluentDeleteTest_FilteredRecord"')->value()
+        );
+    }
+}

--- a/tests/php/Model/Delete/Fixtures/FilteredRecord.php
+++ b/tests/php/Model/Delete/Fixtures/FilteredRecord.php
@@ -2,13 +2,14 @@
 
 namespace TractorCow\Fluent\Tests\Model\Delete\Fixtures;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 use TractorCow\Fluent\Extension\FluentFilteredExtension;
 
 /**
  * @mixin FluentFilteredExtension
  */
-class FilteredRecord extends DataObject
+class FilteredRecord extends DataObject implements TestOnly
 {
     private static $table_name = 'FluentDeleteTest_FilteredRecord';
 

--- a/tests/php/Model/Delete/Fixtures/FilteredRecord.php
+++ b/tests/php/Model/Delete/Fixtures/FilteredRecord.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Model\Delete\Fixtures;
+
+use SilverStripe\ORM\DataObject;
+use TractorCow\Fluent\Extension\FluentFilteredExtension;
+
+/**
+ * @mixin FluentFilteredExtension
+ */
+class FilteredRecord extends DataObject
+{
+    private static $table_name = 'FluentDeleteTest_FilteredRecord';
+
+    private static $extensions = [
+        FluentFilteredExtension::class,
+    ];
+
+    private static $db = [
+        'Title' => 'Varchar(255)',
+    ];
+}

--- a/tests/php/Model/Delete/Fixtures/LocalisedFilteredRecord.php
+++ b/tests/php/Model/Delete/Fixtures/LocalisedFilteredRecord.php
@@ -2,11 +2,12 @@
 
 namespace TractorCow\Fluent\Tests\Model\Delete\Fixtures;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 use TractorCow\Fluent\Extension\FluentExtension;
 use TractorCow\Fluent\Extension\FluentFilteredExtension;
 
-class LocalisedFilteredRecord extends DataObject
+class LocalisedFilteredRecord extends DataObject implements TestOnly
 {
     private static $table_name = 'FluentDeleteTest_LocalisedFilteredRecord';
 

--- a/tests/php/Model/Delete/Fixtures/LocalisedFilteredRecord.php
+++ b/tests/php/Model/Delete/Fixtures/LocalisedFilteredRecord.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Model\Delete\Fixtures;
+
+use SilverStripe\ORM\DataObject;
+use TractorCow\Fluent\Extension\FluentExtension;
+use TractorCow\Fluent\Extension\FluentFilteredExtension;
+
+class LocalisedFilteredRecord extends DataObject
+{
+    private static $table_name = 'FluentDeleteTest_LocalisedFilteredRecord';
+
+    private static $extensions = [
+        FluentExtension::class,
+        FluentFilteredExtension::class,
+    ];
+
+    private static $db = [
+        'Title' => 'Varchar(255)',
+    ];
+}

--- a/tests/php/Model/Delete/Fixtures/LocalisedRecord.php
+++ b/tests/php/Model/Delete/Fixtures/LocalisedRecord.php
@@ -2,13 +2,14 @@
 
 namespace TractorCow\Fluent\Tests\Model\Delete\Fixtures;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 use TractorCow\Fluent\Extension\FluentExtension;
 
 /**
  * @mixin FluentExtension
  */
-class LocalisedRecord extends DataObject
+class LocalisedRecord extends DataObject implements TestOnly
 {
     private static $table_name = 'FluentDeleteTest_LocalisedRecord';
 

--- a/tests/php/Model/Delete/Fixtures/LocalisedRecord.php
+++ b/tests/php/Model/Delete/Fixtures/LocalisedRecord.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Model\Delete\Fixtures;
+
+use SilverStripe\ORM\DataObject;
+use TractorCow\Fluent\Extension\FluentExtension;
+
+/**
+ * @mixin FluentExtension
+ */
+class LocalisedRecord extends DataObject
+{
+    private static $table_name = 'FluentDeleteTest_LocalisedRecord';
+
+    private static $frontend_publish_required = false;
+
+    private static $cms_publish_required = false;
+
+    private static $extensions = [
+        FluentExtension::class,
+    ];
+
+    private static $db = [
+        'Title' => 'Varchar(255)',
+    ];
+}

--- a/tests/php/Model/Delete/Fixtures/Record.php
+++ b/tests/php/Model/Delete/Fixtures/Record.php
@@ -2,9 +2,10 @@
 
 namespace TractorCow\Fluent\Tests\Model\Delete\Fixtures;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 
-class Record extends DataObject
+class Record extends DataObject implements TestOnly
 {
     private static $table_name = 'FluentDeleteTest_Record';
 

--- a/tests/php/Model/Delete/Fixtures/Record.php
+++ b/tests/php/Model/Delete/Fixtures/Record.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Model\Delete\Fixtures;
+
+use SilverStripe\ORM\DataObject;
+
+class Record extends DataObject
+{
+    private static $table_name = 'FluentDeleteTest_Record';
+
+    private static $db = [
+        'Title' => 'Varchar(255)',
+    ];
+}

--- a/tests/php/Model/LocaleTest.php
+++ b/tests/php/Model/LocaleTest.php
@@ -2,14 +2,13 @@
 
 namespace TractorCow\Fluent\Tests\Model;
 
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\CheckboxField;
-use TractorCow\Fluent\Extension\FluentExtension;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
-use SilverStripe\Core\Config\Config;
 
 class LocaleTest extends SapphireTest
 {
@@ -68,7 +67,7 @@ class LocaleTest extends SapphireTest
      * @dataProvider isLocaleProvider
      * @param string $locale
      * @param string $input
-     * @param bool $expected
+     * @param bool   $expected
      */
     public function testIsLocale($locale, $input, $expected)
     {
@@ -143,8 +142,8 @@ class LocaleTest extends SapphireTest
     {
         $esUS = Locale::getByLocale('es_US');
         $this->assertListEquals([
-            [ 'Locale' => 'es_US' ],
-            [ 'Locale' => 'es_ES' ],
+            ['Locale' => 'es_US'],
+            ['Locale' => 'es_ES'],
         ], $esUS->getSiblingLocales());
 
         // Test without domain mode
@@ -152,10 +151,10 @@ class LocaleTest extends SapphireTest
 
         $esUS = Locale::getByLocale('es_US');
         $this->assertListEquals([
-            [ 'Locale' => 'es_US' ],
-            [ 'Locale' => 'es_ES' ],
-            [ 'Locale' => 'en_NZ' ],
-            [ 'Locale' => 'en_AU' ],
+            ['Locale' => 'es_US'],
+            ['Locale' => 'es_ES'],
+            ['Locale' => 'en_NZ'],
+            ['Locale' => 'en_AU'],
         ], $esUS->getSiblingLocales());
     }
 
@@ -211,7 +210,7 @@ class LocaleTest extends SapphireTest
 
         /** @var CheckboxField $checkbox */
         $checkbox = $fields->fieldByName('Root.Main.IsGlobalDefault');
-        $this->assertTrue((bool) $checkbox->Value());
+        $this->assertTrue((bool)$checkbox->Value());
     }
 
     public function testGetLocaleSuffix()


### PR DESCRIPTION
Hello I am back from the dead. :)

This feature attempts to solve some of the inconsistencies involved with deleting objects; If you have an object that's localised, deleting the record should remove that localisation, but not all others.

Acceptance Criteria:
 - When  deleting an object in one locale, it should not delete it from any other locale (unless it's already deleted there).
- After an object has been deleted in all locales the "delete" button deletes the base record.
- Deleting filtered objects should disable this item in the current locale
- Deleting localised objects should delete the localisation for this item in the current locale
- Deleting a localised + filtered object should delete both the localisation, and disable this item in the current locale