### PR TITLE
Revert "FIX Fluent now respects existing base URL prefixes in URL segment fields when no fluent domain exists"

### DIFF
--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -244,9 +244,9 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
             return $this;
         }
 
-        // Mock frontend and set link to parent object / page
-        FluentState::singleton()
-            ->withState(function (FluentState $tempState) use ($segmentField) {
+        // Mock frontend and get link to parent object / page
+        $baseURL = FluentState::singleton()
+            ->withState(function (FluentState $tempState) {
                 $tempState->setIsDomainMode(true);
                 $tempState->setIsFrontend(true);
 
@@ -264,14 +264,15 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
                 if ($domain) {
                     $parentBase = Controller::join_links($domain->Link(), Director::baseURL());
                 } else {
-                    // Use any existing pre-configured base URL prefix for the field
-                    $parentBase = $segmentField->getURLPrefix();
+                    $parentBase = Director::absoluteBaseURL();
                 }
 
                 // Join base / relative links
-                $segmentField->setURLPrefix(Controller::join_links($parentBase, $parentRelative));
+                return Controller::join_links($parentBase, $parentRelative);
             });
 
+
+        $segmentField->setURLPrefix($baseURL);
         return $this;
     }
 

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -316,7 +316,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
                 $fields = $this->objFromFixture(Page::class, $fixture)->getCMSFields();
 
                 /** @var SiteTreeURLSegmentField $segmentField */
-                $segmentField = $fields->dataFieldByName('URLSegment');
+                $segmentField = $fields->fieldByName('Root.Main.URLSegment');
                 $this->assertInstanceOf(SiteTreeURLSegmentField::class, $segmentField);
 
                 $this->assertSame($expected, $segmentField->getURLPrefix());


### PR DESCRIPTION
Reverts tractorcow-farm/silverstripe-fluent#523

Resolves https://github.com/tractorcow-farm/silverstripe-fluent/issues/538