### PR TITLE
Link to issue 75 returning 404

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "support": {
-        "issues": "http://github.com/tractorcow/silverstripe-fluent/issues"
+        "issues": "http://github.com/tractorcow-farm/silverstripe-fluent/issues"
     },
     "require": {
         "silverstripe/vendor-plugin": "^1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/tractorcow/silverstripe-fluent.git"
+    "url": "git://github.com/tractorcow-farm/silverstripe-fluent.git"
   },
   "keywords": [
     "fluent",
@@ -23,9 +23,9 @@
   "author": "Damian Mooyman",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/tractorcow/silverstripe-fluent/issues"
+    "url": "https://github.com/tractorcow-farm/silverstripe-fluent/issues"
   },
-  "homepage": "https://github.com/tractorcow/silverstripe-fluent",
+  "homepage": "https://github.com/tractorcow-farm/silverstripe-fluent",
   "devDependencies": {
     "@silverstripe/webpack-config": "^0.4.1"
   },

--- a/readme.md
+++ b/readme.md
@@ -25,12 +25,12 @@ Back end control is provided by a simple CMS filter.
 
 ![Locale Menu](docs/en/images/menu.png "Locale menu")
 
-Also, please [report any issues](https://github.com/tractorcow/silverstripe-fluent/issues)
+Also, please [report any issues](https://github.com/tractorcow-farm/silverstripe-fluent/issues)
 you may encounter, as it helps us all out!
 
 ## Credits and Authors
 
- * Damian Mooyman - <https://github.com/tractorcow/silverstripe-fluent>
+ * Damian Mooyman - <https://github.com/tractorcow-farm/silverstripe-fluent>
  * Robbie Averill - <https://github.com/robbieaverill> Migrating to SilverStripe 4.0
  * Attribution to Michael (dAKirby309) for his metro translate icon - <http://dakirby309.deviantart.com/>
 

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -80,7 +80,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
 
             // For all pages on a domain where there is only a single locale,
             // then the domain itself is sufficient to distinguish that domain
-            // See https://github.com/tractorcow/silverstripe-fluent/issues/75
+            // See https://github.com/tractorcow-farm/silverstripe-fluent/issues/75
             if ($localeObj->getIsOnlyLocale()) {
                 return;
             }


### PR DESCRIPTION
Updated github links to point to tractorcow-farm. Link to [Issue 75](https://github.com/tractorcow-farm/silverstripe-fluent/blob/master/src/Extension/FluentSiteTreeExtension.php#L83) resulting in 404.