### PR TITLE
addFluentBadge should return existing badge

### DIFF
--- a/src/Extension/FluentBadgeExtension.php
+++ b/src/Extension/FluentBadgeExtension.php
@@ -58,7 +58,7 @@ class FluentBadgeExtension extends Extension
         if (!FluentState::singleton()->getLocale()
             || !$record->has_extension(FluentVersionedExtension::class)
         ) {
-            return null;
+            return $badgeField;
         }
 
         $fluentBadge = $this->getBadge($record);


### PR DESCRIPTION
Fixes a bug where an existing badge (like "modified") was destroyed in unversioned, translated data objects