### PR TITLE
Travis config update, remove branch aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: php
 
-dist: trusty
+dist: xenial
+
+services:
+  - mysql
+
+addons:
+  apt:
+    packages:
+      - tidy
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,6 @@
         "squizlabs/php_codesniffer": "^3"
     },
     "extra": {
-        "branch-alias": {
-            "dev-master": "4.5.x-dev"
-        },
         "expose": [
             "client/dist"
         ]


### PR DESCRIPTION
This makes "master" branch to be "next major".
After it's merged we should be able to to create a new branch "4" for the next minor.

That should allow us to follow the same branch naming conventions as the core modules.

Part of https://github.com/silverstripe/cwp-recipe-kitchen-sink/issues/46#issuecomment-547734409