### PR TITLE
Fluent dev state fix

### DIFF
--- a/src/Dev/FluentTestState.php
+++ b/src/Dev/FluentTestState.php
@@ -34,6 +34,8 @@ class FluentTestState implements TestState
      */
     public function setUpOnce($class)
     {
+        // Clear locale static caching between tests.
+        Locale::clearCached();
     }
 
     /**


### PR DESCRIPTION
Fixes an issue with Unit tests not clearing the Locale cache properly.

This covers the situation when Unit test 1 populates the locale cache and Unit test 2 uses following setup:

```
protected function setUp()
{
    FluentState::singleton()->withState(function (FluentState $state): void {
        $state->setLocale('<some_locale>');

        parent::setUp();
    });
}
```

Note that wrapping `setUp` inside fluent state is really handy for unit tests that require all objects defined in the fixtures to use only one locale.

## Related issues

https://github.com/tractorcow-farm/silverstripe-fluent/issues/591