### PR TITLE
Latest version issue fix

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -445,20 +445,12 @@ class FluentVersionedExtension extends FluentExtension
         //fetch alias from subselect
         $newFrom = $subSelect->getFrom();
         $alias = trim(key($newFrom), '"');
-        //join versioned and localised table
-        $onPredicate = [
-            //first connect to the correct record
-            "\"{$alias}\".\"RecordID\" = \"{$versionedTable}\".\"RecordID\"",
-            //and then connect version with localised
-            "\"{$alias}\".\"Version\" = \"{$versionedTable}\".\"Version\""
-        ];
-        $subSelect->addInnerJoin($versionedTable, join(" AND ", $onPredicate));
+        //add inner join to localised table
+        $subSelect->addInnerJoin($versionedTable, "\"{$alias}\".\"RecordID\" = \"{$versionedTable}\".\"RecordID\" AND \"{$alias}\".\"Version\" = \"{$versionedTable}\".\"Version\"");
 
         //get current locale
         $locale = FluentState::singleton()->getLocale();
         //finally, update subselect to include requested locale
         $subSelect->addWhere("\"{$versionedTable}\".\"Locale\" = '{$locale}'");
-        //@todo: test if following line is needed
-        // $subSelect->addGroupBy("\"{$alias}\".RecordID");
     }
 }


### PR DESCRIPTION
Scenario: You have a data object that's both versioned and localised. Let's say that locales available are en_US and nl_NL. You first save english, and after some time, dutch version. Later, somewhere it the code you want to get latest version of that data object.

Expected behaviour: Depending of the locale set in FluentState, you will get latest version written in that locale.
Actual behaviour: if latest version is written in same locale which is set, you will get it. Otherwise returns false.

Or, following example above, if locale is set to nl_NL, you'll get the latest version. If it's en_US - no luck - since there is a version after it, but in different locale.

This PR addresses that issue and makes Versioned return latest version in requested locale, no matter if there are any newer versions in other locales.