### PR TITLE
Redundant copy locale actions fix (alpha 5).

### DIFF
--- a/src/Forms/CopyLocaleAction.php
+++ b/src/Forms/CopyLocaleAction.php
@@ -75,7 +75,7 @@ class CopyLocaleAction extends BaseAction
      */
     public function handleAction(GridField $gridField, $actionName, $arguments, $data)
     {
-        if (!in_array($actionName, ['fluentcopyto', 'fluentcopyfrom'])) {
+        if (!$this->validateAction($actionName, $arguments['FromLocale'], $arguments['ToLocale'])) {
             return;
         }
 
@@ -185,5 +185,26 @@ class CopyLocaleAction extends BaseAction
             return $this->isTo ? self::COPY_TO : self::COPY_FROM;
         }
         return null;
+    }
+
+    /**
+     * Ensures that action is executed only once and not once per per locale
+     *
+     * @param string $actionName
+     * @param string $fromLocale
+     * @param string $toLocale
+     * @return bool
+     */
+    private function validateAction($actionName, $fromLocale, $toLocale)
+    {
+        if ($actionName === 'fluentcopyto' && $this->otherLocale === $fromLocale) {
+            return true;
+        }
+
+        if ($actionName === 'fluentcopyfrom' && $this->otherLocale === $toLocale) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
# Redundant copy locale actions fix (alpha 5)

* `CopyLocaleAction` component is created as many times as there are locales available, see code snippet below (from `FluentExtension`):

```
foreach (Locale::getCached() as $locale) {
    $config->addComponents([
        new CopyLocaleAction($locale->Locale, true),
        new CopyLocaleAction($locale->Locale, false),
    ]);
}
```

* these components have slightly different UI but they all subscribe to the same action
* whenever either `copy to` or` copy from` action is executed, all of the components will execute the action
* this change-set fixes this by adding additional condition to make the components aware of the locale they are responsible for

## Related issues

https://github.com/tractorcow-farm/silverstripe-fluent/issues/624