### PR TITLE
Copy locale action extension points.

### DIFF
--- a/src/Forms/CopyLocaleAction.php
+++ b/src/Forms/CopyLocaleAction.php
@@ -106,6 +106,10 @@ class CopyLocaleAction extends BaseAction
                 }
                 $destinationState->setLocale($toLocale->getLocale());
 
+                $fromLocale = $arguments['FromLocale'];
+                $toLocale = $arguments['ToLocale'];
+                $record->invokeWithExtensions('onBeforeCopyLocale', $fromLocale, $toLocale);
+
                 // Write
                 /** @var DataObject|Versioned $record */
                 if ($record->hasExtension(Versioned::class)) {
@@ -114,6 +118,8 @@ class CopyLocaleAction extends BaseAction
                     $record->forceChange();
                     $record->write();
                 }
+
+                $record->invokeWithExtensions('onAfterCopyLocale', $fromLocale, $toLocale);
             });
         });
     }


### PR DESCRIPTION
# Copy locale action extension points

* adds useful extension points for the `copy locale` action
* no functional changes otherwise
* very useful for dealing with special handling of related objects which are localised by relation (indirectly), most notable example would be `Elemental`

## Related issues

https://github.com/tractorcow-farm/silverstripe-fluent/issues/626