### PR TITLE
NEW: Localisation manager UI improvements.

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -870,6 +870,30 @@ class FluentExtension extends DataExtension
     }
 
     /**
+     * Get list of locales where record is localised in
+     *
+     * @return array
+     */
+    public function LocaleInstances()
+    {
+        $locales = [];
+
+        foreach (Locale::getCached() as $locale) {
+            /** @var Locale $locale */
+            $info = $this->owner->LocaleInformation($locale->getLocale());
+            $source = $info->SourceLocale();
+
+            if ($source->Locale !== $locale->Locale) {
+                continue;
+            }
+
+            $locales[] = $locale;
+        }
+
+        return $locales;
+    }
+
+    /**
      * Return the linking mode for the current locale and object
      *
      * @param string $locale

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -874,14 +874,14 @@ class FluentExtension extends DataExtension
      *
      * @return array
      */
-    public function LocaleInstances()
+    public function getLocaleInstances(): array
     {
         $locales = [];
 
         foreach (Locale::getCached() as $locale) {
             /** @var Locale $locale */
             $info = $this->owner->LocaleInformation($locale->getLocale());
-            $source = $info->SourceLocale();
+            $source = $info->getSourceLocale();
 
             if ($source->Locale !== $locale->Locale) {
                 continue;
@@ -1102,32 +1102,32 @@ class FluentExtension extends DataExtension
         $summaryColumns['Status'] = [
             'title' => 'Status',
             'callback' => function (Locale $object) {
-                if ($object->RecordLocale()) {
-                    if ($object->RecordLocale()->IsDraft()) {
-                        return _t(self::class . '.LOCALISED', 'Localised');
-                    }
-
-                    return _t(self::class . '.NOTLOCALISED', 'Not localised');
+                if (!$object->RecordLocale()) {
+                    return '';
                 }
 
-                return '';
+                if ($object->RecordLocale()->IsDraft()) {
+                    return _t(self::class . '.LOCALISED', 'Localised');
+                }
+
+                return _t(self::class . '.NOTLOCALISED', 'Not localised');
             }
         ];
 
         $summaryColumns['Source'] = [
             'title' => 'Source',
             'callback' => function (Locale $object) {
-                if ($object->RecordLocale()) {
-                    $sourceLocale = $object->RecordLocale()->SourceLocale();
-
-                    if ($sourceLocale) {
-                        return $sourceLocale->getLongTitle();
-                    }
-
-                    return _t(self::class . '.NOSOURCE', 'No source');
+                if (!$object->RecordLocale()) {
+                    return '';
                 }
 
-                return '';
+                $sourceLocale = $object->RecordLocale()->getSourceLocale();
+
+                if ($sourceLocale) {
+                    return $sourceLocale->getLongTitle();
+                }
+
+                return _t(self::class . '.NOSOURCE', 'No source');
             }
         ];
     }
@@ -1165,13 +1165,13 @@ class FluentExtension extends DataExtension
         foreach (Locale::getCached() as $locale) {
             if ($copyToLocaleEnabled) {
                 $config->addComponents([
-                    new CopyLocaleAction($locale->Locale, true),
+                    CopyLocaleAction::create($locale->Locale, true),
                 ]);
             }
 
             if ($copyFromLocaleEnabled) {
                 $config->addComponents([
-                    new CopyLocaleAction($locale->Locale, false),
+                    CopyLocaleAction::create($locale->Locale, false),
                 ]);
             }
         }

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -155,6 +155,30 @@ class FluentExtension extends DataExtension
     private static $data_exclude = [];
 
     /**
+     * Enable copy to locale action in the localisation manager
+     *
+     * @config
+     * @var bool
+     */
+    private static $copy_to_locale_enabled = true;
+
+    /**
+     * Enable copy from locale action in the localisation manager
+     *
+     * @config
+     * @var bool
+     */
+    private static $copy_from_locale_enabled = true;
+
+    /**
+     * Enable batch actions in the edit form
+     *
+     * @config
+     * @var bool
+     */
+    private static $batch_actions_enabled = true;
+
+    /**
      * Cache of localised fields for this model
      */
     protected $localisedFields = [];
@@ -1051,10 +1075,35 @@ class FluentExtension extends DataExtension
      */
     public function updateLocalisationTabColumns(&$summaryColumns)
     {
-        $summaryColumns['IsDraft'] = [
-            'title'    => 'Saved',
+        $summaryColumns['Status'] = [
+            'title' => 'Status',
             'callback' => function (Locale $object) {
-                return $object->RecordLocale()->IsDraft() ? 'Saved' : '';
+                if ($object->RecordLocale()) {
+                    if ($object->RecordLocale()->IsDraft()) {
+                        return 'Localised';
+                    }
+
+                    return 'Not localised';
+                }
+
+                return '';
+            }
+        ];
+
+        $summaryColumns['Source'] = [
+            'title' => 'Source',
+            'callback' => function (Locale $object) {
+                if ($object->RecordLocale()) {
+                    $sourceLocale = $object->RecordLocale()->SourceLocale();
+
+                    if ($sourceLocale) {
+                        return $sourceLocale->getLongTitle();
+                    }
+
+                    return 'No source';
+                }
+
+                return '';
             }
         ];
     }
@@ -1085,12 +1134,22 @@ class FluentExtension extends DataExtension
             new GroupActionMenu(GridField_ActionMenuItem::DEFAULT_GROUP)
         ]);
 
+        $copyToLocaleEnabled = $this->owner->config()->get('copy_to_locale_enabled');
+        $copyFromLocaleEnabled = $this->owner->config()->get('copy_from_locale_enabled');
+
         // Add each copy from / to
         foreach (Locale::getCached() as $locale) {
-            $config->addComponents([
-                new CopyLocaleAction($locale->Locale, true),
-                new CopyLocaleAction($locale->Locale, false),
-            ]);
+            if ($copyToLocaleEnabled) {
+                $config->addComponents([
+                    new CopyLocaleAction($locale->Locale, true),
+                ]);
+            }
+
+            if ($copyFromLocaleEnabled) {
+                $config->addComponents([
+                    new CopyLocaleAction($locale->Locale, false),
+                ]);
+            }
         }
     }
 }

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -1080,10 +1080,10 @@ class FluentExtension extends DataExtension
             'callback' => function (Locale $object) {
                 if ($object->RecordLocale()) {
                     if ($object->RecordLocale()->IsDraft()) {
-                        return 'Localised';
+                        return _t(self::class . '.LOCALISED', 'Localised');
                     }
 
-                    return 'Not localised';
+                    return _t(self::class . '.NOTLOCALISED', 'Not localised');
                 }
 
                 return '';
@@ -1100,7 +1100,7 @@ class FluentExtension extends DataExtension
                         return $sourceLocale->getLongTitle();
                     }
 
-                    return 'No source';
+                    return _t(self::class . '.NOSOURCE', 'No source');
                 }
 
                 return '';

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\LiteralField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use TractorCow\Fluent\Extension\Traits\FluentAdminTrait;
 use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\Model\RecordLocale;
 use TractorCow\Fluent\State\FluentState;
 
 // Soft dependency on CMS module
@@ -239,15 +240,25 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
                 );
             }
         } else {
-            // If frontend publishing is *not* required, then we have two possibilities.
+            // If frontend publishing is *not* required, then we have multiple possibilities.
             if (!$this->isDraftedInLocale()) {
-                // Our content hasn't been drafted or published. If this Locale has a Fallback, then content might be
-                // getting inherited from that Fallback.
-                $message = _t(
-                    __CLASS__ . '.LOCALESTATUSFLUENTINHERITED',
-                    'Content for this page may be inherited from another locale. If you wish you make an ' .
-                    'independent copy of this page, please use one of the "Copy" actions provided.'
-                );
+                $info = RecordLocale::create($this->owner, Locale::getCurrentLocale());
+
+                // Our content hasn't been drafted or published.
+                if ($info->SourceLocale()) {
+                    // If this Locale has a Fallback, then content might be getting inherited from that Fallback.
+                    $message = _t(
+                        __CLASS__ . '.LOCALESTATUSFLUENTINHERITED',
+                        'Content for this page may be inherited from another locale. If you wish you make an ' .
+                        'independent copy of this page, please use one of the "Copy" actions provided.'
+                    );
+                } else {
+                    // This locale doesn't have any content source
+                    $message = _t(
+                        __CLASS__ . '.LOCALESTATUSFLUENTUNKNOWN',
+                        'No content is available for this page. Please localise this page or provide a locale fallback.'
+                    );
+                }
             } elseif (!$this->isPublishedInLocale()) {
                 // Our content has been saved to draft, but hasn't yet been published. That published content may be
                 // coming from a Fallback.

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -2,7 +2,6 @@
 
 namespace TractorCow\Fluent\Extension;
 
-use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\CMS\Controllers\RootURLController;
 use SilverStripe\CMS\Forms\SiteTreeURLSegmentField;
 use SilverStripe\CMS\Model\SiteTree;
@@ -225,7 +224,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
         // Update the state of publish action (if needed)
         $this->updatePublishState($actions);
 
-        // Updat unpublish and archive actions
+        // Update unpublish and archive actions
         $this->updateMoreOptionsActions($actions);
 
         // Add extra fluent menu
@@ -270,7 +269,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
                 $info = RecordLocale::create($this->owner, Locale::getCurrentLocale());
 
                 // Our content hasn't been drafted or published.
-                if ($info->SourceLocale()) {
+                if ($info->getSourceLocale()) {
                     // If this Locale has a Fallback, then content might be getting inherited from that Fallback.
                     $message = _t(
                         __CLASS__ . '.LOCALESTATUSFLUENTINHERITED',
@@ -439,7 +438,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
         // this is needed because the default interface looks
         // at the base record instead of the localised page
         $publishAction
-            ->setTitle(_t(SiteTree::class . '.BUTTONPUBLISHED', 'Published'))
+            ->setTitle(_t('SilverStripe\\CMS\\Model\\SiteTree.BUTTONPUBLISHED', 'Published'))
             ->removeExtraClass(
                 'btn-primary font-icon-rocket btn-outline-primary font-icon-tick'
             )
@@ -452,7 +451,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
         // If staged and live is different we change the button to "Publish"
         // as the page hasn't been published
         $publishAction
-            ->setTitle(_t(SiteTree::class . '.BUTTONSAVEPUBLISH', 'Publish'))
+            ->setTitle(_t('SilverStripe\\CMS\\Model\\SiteTree.BUTTONSAVEPUBLISH', 'Publish'))
             ->addExtraClass('btn-primary font-icon-rocket')
             ->removeExtraClass('btn-outline-primary font-icon-tick');
     }
@@ -485,7 +484,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
             return;
         }
 
-        $archiveAction->setTitle(_t(CMSMain::class . '.ARCHIVE', 'Archive'));
+        $archiveAction->setTitle(_t('SilverStripe\\CMS\\Controllers\\CMSMain.ARCHIVE', 'Archive'));
     }
 
     /**
@@ -493,7 +492,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
      *
      * @param FieldList $actions
      */
-    protected function updateLocaliseActions(FieldList $actions)
+    protected function updateLocaliseActions(FieldList $actions): void
     {
         $owner = $this->owner;
 
@@ -517,7 +516,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
      *
      * @param FieldList $actions
      */
-    protected function updateInformationPanel(FieldList $actions)
+    protected function updateInformationPanel(FieldList $actions): void
     {
         $owner = $this->owner;
 

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -348,7 +348,7 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
             return false;
         }
 
-        $locale = $locale ?: FluentState::singleton()->getLocale();
+        $locale = $locale ?: $this->getRecordLocale()->Locale;
 
         // Potentially no Locales have been created in the system yet.
         if (!$locale) {

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -322,7 +322,13 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
      */
     public function existsInLocale($locale = null)
     {
-        return $this->isDraftedInLocale($locale) || $this->isPublishedInLocale($locale);
+        $stage = Versioned::get_stage() ?: Versioned::DRAFT;
+
+        if ($stage === Versioned::DRAFT) {
+            return $this->isDraftedInLocale($locale);
+        }
+
+        return $this->isPublishedInLocale($locale);
     }
 
     /**

--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -55,6 +55,10 @@ trait FluentAdminTrait
             return;
         }
 
+        if (!$record->config()->get('batch_actions_enabled')) {
+            return;
+        }
+
         // Skip if record isn't saved
         if (!$record->isInDB()) {
             return;

--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -651,6 +651,16 @@ trait FluentAdminTrait
         $deleteAction
             ->setTitle(_t(FluentExtension::class . '.Unlocalise', 'Unlocalise'))
             ->removeExtraClass('font-icon-trash-bin')
-            ->addExtraClass('font-icon-translatable');
+            ->addExtraClass('font-icon-translatable')
+            ->setAttribute(
+                'title',
+                _t(
+                    FluentExtension::class . '.UnlocaliseTooltip',
+                    'Remove {name} from current locale',
+                    [
+                        'name' => $record->i18n_singular_name()
+                    ]
+                )
+            );
     }
 }

--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -585,9 +585,9 @@ trait FluentAdminTrait
      * - not localised (save label)
      *
      * @param FieldList $actions
-     * @param DataObject $record
+     * @param DataObject|FluentExtension $record
      */
-    protected function updateSaveAction(FieldList $actions, DataObject $record)
+    protected function updateSaveAction(FieldList $actions, DataObject $record): void
     {
         if ($record->hasExtension(Versioned::class)) {
             return;
@@ -606,7 +606,7 @@ trait FluentAdminTrait
 
         // update save action label to localise in case record is not localised yet
         $saveAction
-            ->setTitle(_t(FluentExtension::class . '.Localise', 'Localise'))
+            ->setTitle(_t('TractorCow\\Fluent\\Extension\\FluentExtension.Localise', 'Localise'))
             ->removeExtraClass('font-icon-save')
             ->addExtraClass('font-icon-translatable');
     }
@@ -621,7 +621,7 @@ trait FluentAdminTrait
      * @param FieldList $actions
      * @param DataObject|FluentExtension $record
      */
-    protected function updateDeleteAction(FieldList $actions, DataObject $record)
+    protected function updateDeleteAction(FieldList $actions, DataObject $record): void
     {
         if ($record->hasExtension(Versioned::class)) {
             return;
@@ -634,7 +634,7 @@ trait FluentAdminTrait
             return;
         }
 
-        $locales = $record->LocaleInstances();
+        $locales = $record->getLocaleInstances();
 
         if (count($locales) <= 1) {
             // keep the action unchanged as this is the last locale
@@ -649,13 +649,13 @@ trait FluentAdminTrait
 
         // update delete action label to unlocalise in case there are still more localised instances of the record left
         $deleteAction
-            ->setTitle(_t(FluentExtension::class . '.Unlocalise', 'Unlocalise'))
+            ->setTitle(_t('TractorCow\\Fluent\\Extension\\FluentExtension.Unlocalise', 'Unlocalise'))
             ->removeExtraClass('font-icon-trash-bin')
             ->addExtraClass('font-icon-translatable')
             ->setAttribute(
                 'title',
                 _t(
-                    FluentExtension::class . '.UnlocaliseTooltip',
+                    'TractorCow\\Fluent\\Extension\\FluentExtension.UnlocaliseTooltip',
                     'Remove {name} from current locale',
                     [
                         'name' => $record->i18n_singular_name()

--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -55,10 +55,6 @@ trait FluentAdminTrait
             return;
         }
 
-        if (!$record->config()->get('batch_actions_enabled')) {
-            return;
-        }
-
         // Skip if record isn't saved
         if (!$record->isInDB()) {
             return;
@@ -77,8 +73,19 @@ trait FluentAdminTrait
             return;
         }
 
-        // If there are no results, this will pass as true
         $locale = Locale::getCurrentLocale();
+
+        if (!$locale) {
+            // Potentially no Locales have been created in the system yet.
+            return;
+        }
+
+        $this->updateSaveAction($actions, $record);
+        $this->updateDeleteAction($actions, $record);
+
+        if (!$record->config()->get('batch_actions_enabled')) {
+            return;
+        }
 
         // Build root tabset that makes up the menu
         $rootTabSet = TabSet::create('FluentMenu')->setTemplate(
@@ -569,5 +576,81 @@ trait FluentAdminTrait
                 $doSomething($stage);
             });
         }
+    }
+
+    /**
+     * Update save action based on localisation state
+     * valid states:
+     * - localised (localise label)
+     * - not localised (save label)
+     *
+     * @param FieldList $actions
+     * @param DataObject $record
+     */
+    protected function updateSaveAction(FieldList $actions, DataObject $record)
+    {
+        if ($record->hasExtension(Versioned::class)) {
+            return;
+        }
+
+        if ($record->existsInLocale()) {
+            // keep the action unchanged as the record is localised
+            return;
+        }
+
+        $saveAction = $actions->fieldByName('MajorActions.action_doSave');
+
+        if (!$saveAction) {
+            return;
+        }
+
+        // update save action label to localise in case record is not localised yet
+        $saveAction
+            ->setTitle(_t(FluentExtension::class . '.Localise', 'Localise'))
+            ->removeExtraClass('font-icon-save')
+            ->addExtraClass('font-icon-translatable');
+    }
+
+    /**
+     * Update delete action based on localisation state
+     * valid states:
+     * - localised more than one locale (unlocalise label)
+     * - localised in one locale (delete label)
+     * - not localised (remove the action)
+     *
+     * @param FieldList $actions
+     * @param DataObject|FluentExtension $record
+     */
+    protected function updateDeleteAction(FieldList $actions, DataObject $record)
+    {
+        if ($record->hasExtension(Versioned::class)) {
+            return;
+        }
+
+        if (!$record->existsInLocale()) {
+            // record is not localised  - remove the action
+            $actions->removeByName('action_doDelete');
+
+            return;
+        }
+
+        $locales = $record->LocaleInstances();
+
+        if (count($locales) <= 1) {
+            // keep the action unchanged as this is the last locale
+            return;
+        }
+
+        $deleteAction = $actions->fieldByName('action_doDelete');
+
+        if (!$deleteAction) {
+            return;
+        }
+
+        // update delete action label to unlocalise in case there are still more localised instances of the record left
+        $deleteAction
+            ->setTitle(_t(FluentExtension::class . '.Unlocalise', 'Unlocalise'))
+            ->removeExtraClass('font-icon-trash-bin')
+            ->addExtraClass('font-icon-translatable');
     }
 }

--- a/src/Extension/Traits/FluentBadgeTrait.php
+++ b/src/Extension/Traits/FluentBadgeTrait.php
@@ -72,7 +72,7 @@ trait FluentBadgeTrait
 
         // Build new badge
         $badgeClasses = ['badge', 'fluent-badge'];
-        if ($info->IsLive()) {
+        if ($info->IsPublished()) {
             // If the object has been localised in the current locale, show a "localised" state
             $badgeClasses[] = 'fluent-badge--default';
             $tooltip = _t(

--- a/src/Extension/Traits/FluentBadgeTrait.php
+++ b/src/Extension/Traits/FluentBadgeTrait.php
@@ -72,7 +72,7 @@ trait FluentBadgeTrait
 
         // Build new badge
         $badgeClasses = ['badge', 'fluent-badge'];
-        if ($info->IsPublished()) {
+        if ($info->IsLive()) {
             // If the object has been localised in the current locale, show a "localised" state
             $badgeClasses[] = 'fluent-badge--default';
             $tooltip = _t(

--- a/src/Extension/Traits/FluentBadgeTrait.php
+++ b/src/Extension/Traits/FluentBadgeTrait.php
@@ -68,38 +68,40 @@ trait FluentBadgeTrait
         $locale,
         $extraProperties = []
     ) {
-        $info = new RecordLocale($record, $locale);
+        $info = RecordLocale::create($record, $locale);
 
         // Build new badge
         $badgeClasses = ['badge', 'fluent-badge'];
-        if ($info->IsPublished()) {
+        if ($info->IsDraft()) {
             // If the object has been localised in the current locale, show a "localised" state
             $badgeClasses[] = 'fluent-badge--default';
             $tooltip = _t(
-                __TRAIT__ . '.BadgePublished',
-                'Published in {locale}',
+                __TRAIT__ . '.BadgeLocalised',
+                'Localised in {locale}',
                 [
                     'locale' => $locale->getTitle()
                 ]
             );
-        } elseif ($info->IsDraft()) {
-            // Otherwise the state is that it hasn't yet been localised in the current locale, so is "invisible"
+        } elseif ($info->SourceLocale()) {
+            // If object is inheriting content from another locale show the source
             $badgeClasses[] = 'fluent-badge--localised';
             $tooltip = _t(
-                __TRAIT__ . '.BadgeDraft',
-                'Saved but not visible in {locale}',
+                __TRAIT__ . '.BadgeInherited',
+                'Inherited from {locale}',
                 [
-                    'locale' => $locale->getTitle()
+                    'locale' => $info->SourceLocale()->getTitle()
                 ]
             );
         } else {
-            // Otherwise the state is that it hasn't yet been localised in the current locale, so is "invisible"
+            // Otherwise the object is missing a content source and needs to be remedied
+            // by either localising or seting up a locale fallback
             $badgeClasses[] = 'fluent-badge--invisible';
             $tooltip = _t(
                 __TRAIT__ . '.BaggeInvisible',
-                '{type} is not visible in this locale',
+                '{type} has no available content in {locale}, localise the {type} or provide a locale fallback',
                 [
-                    'type' => $record->i18n_singular_name()
+                    'type' => $record->i18n_singular_name(),
+                    'locale' => $locale->getTitle(),
                 ]
             );
         }

--- a/src/Extension/Traits/FluentBadgeTrait.php
+++ b/src/Extension/Traits/FluentBadgeTrait.php
@@ -82,14 +82,14 @@ trait FluentBadgeTrait
                     'locale' => $locale->getTitle()
                 ]
             );
-        } elseif ($info->SourceLocale()) {
+        } elseif ($info->getSourceLocale()) {
             // If object is inheriting content from another locale show the source
             $badgeClasses[] = 'fluent-badge--localised';
             $tooltip = _t(
                 __TRAIT__ . '.BadgeInherited',
                 'Inherited from {locale}',
                 [
-                    'locale' => $info->SourceLocale()->getTitle()
+                    'locale' => $info->getSourceLocale()->getTitle()
                 ]
             );
         } else {

--- a/src/Model/RecordLocale.php
+++ b/src/Model/RecordLocale.php
@@ -351,20 +351,14 @@ class RecordLocale extends ViewableData
     {
         /** @var DataObject|FluentExtension $record */
         $record = $this->getOriginalRecord();
-        $validationMethod = 'existsInLocale';
 
-        if ($record->hasExtension(FluentVersionedExtension::class)) {
-            $stage = Versioned::get_stage() ?: Versioned::DRAFT;
-            $validationMethod = $stage === Versioned::DRAFT ? 'isDraftedInLocale' : 'isPublishedInLocale';
-        }
-
-        if ($record->{$validationMethod}($this->getLocale())) {
+        if ($record->existsInLocale($this->getLocale())) {
             return $this->getLocaleObject();
         }
 
         /** @var Locale $fallback */
         foreach ($this->getLocaleObject()->Fallbacks() as $fallback) {
-            if (!$record->{$validationMethod}($fallback->Locale)) {
+            if (!$record->existsInLocale($fallback->Locale)) {
                 continue;
             }
 

--- a/src/Model/RecordLocale.php
+++ b/src/Model/RecordLocale.php
@@ -263,7 +263,7 @@ class RecordLocale extends ViewableData
      * @param bool $inLocale
      * @return bool
      */
-    public function IsPublished($inLocale = false)
+    public function IsPublished($inLocale = false): bool
     {
         // If object is filtered, object is not available (regardless of published status)
         if (!$inLocale && !$this->IsVisible()) {
@@ -325,7 +325,7 @@ class RecordLocale extends ViewableData
      *
      * @return bool
      */
-    public function StagesDiffer()
+    public function getStagesDiffer(): bool
     {
         if (!$this->IsPublished(true)) {
             return false;
@@ -347,7 +347,7 @@ class RecordLocale extends ViewableData
      *
      * @return Locale|null
      */
-    public function SourceLocale()
+    public function getSourceLocale(): ?Locale
     {
         /** @var DataObject|FluentExtension $record */
         $record = $this->getOriginalRecord();

--- a/src/Model/RecordLocale.php
+++ b/src/Model/RecordLocale.php
@@ -351,14 +351,20 @@ class RecordLocale extends ViewableData
     {
         /** @var DataObject|FluentExtension $record */
         $record = $this->getOriginalRecord();
+        $validationMethod = 'existsInLocale';
 
-        if ($record->existsInLocale($this->getLocale())) {
+        if ($record->hasExtension(FluentVersionedExtension::class)) {
+            $stage = Versioned::get_stage() ?: Versioned::DRAFT;
+            $validationMethod = $stage === Versioned::DRAFT ? 'isDraftedInLocale' : 'isPublishedInLocale';
+        }
+
+        if ($record->{$validationMethod}($this->getLocale())) {
             return $this->getLocaleObject();
         }
 
         /** @var Locale $fallback */
         foreach ($this->getLocaleObject()->Fallbacks() as $fallback) {
-            if (!$record->existsInLocale($fallback->Locale)) {
+            if (!$record->{$validationMethod}($fallback->Locale)) {
                 continue;
             }
 

--- a/src/View/FluentTemplateGlobalProvider.php
+++ b/src/View/FluentTemplateGlobalProvider.php
@@ -36,7 +36,7 @@ class FluentTemplateGlobalProvider implements TemplateGlobalProvider
      *
      * @return Locale|null
      */
-    public static function getCurrentLocaleObject()
+    public static function getCurrentLocaleObject(): ?Locale
     {
         return Locale::getCurrentLocale();
     }

--- a/src/View/FluentTemplateGlobalProvider.php
+++ b/src/View/FluentTemplateGlobalProvider.php
@@ -3,6 +3,7 @@
 namespace TractorCow\Fluent\View;
 
 use SilverStripe\View\TemplateGlobalProvider;
+use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
 
 class FluentTemplateGlobalProvider implements TemplateGlobalProvider
@@ -13,6 +14,9 @@ class FluentTemplateGlobalProvider implements TemplateGlobalProvider
             'CurrentLocale' => [
                 'method' => 'getCurrentLocale',
                 'casting' => 'Text',
+            ],
+            'CurrentLocaleObject' => [
+                'method' => 'getCurrentLocaleObject',
             ],
         ];
     }
@@ -25,5 +29,15 @@ class FluentTemplateGlobalProvider implements TemplateGlobalProvider
     public static function getCurrentLocale()
     {
         return FluentState::singleton()->getLocale();
+    }
+
+    /**
+     * Returns the current locale object
+     *
+     * @return Locale|null
+     */
+    public static function getCurrentLocaleObject()
+    {
+        return Locale::getCurrentLocale();
     }
 }

--- a/tests/php/Extension/FluentBadgeExtensionTest.php
+++ b/tests/php/Extension/FluentBadgeExtensionTest.php
@@ -64,7 +64,7 @@ class FluentBadgeExtensionTest extends SapphireTest
             $result = $this->extension->getBadge($this->mockPage);
             $this->assertInstanceOf(DBHTMLText::class, $result);
             $this->assertContains('fluent-badge--default', $result->getValue());
-            $this->assertContains('Published in', $result->getValue());
+            $this->assertContains('Localised in', $result->getValue());
             $this->assertContains('NZ', $result->getValue(), 'Badge shows owner locale');
         });
     }
@@ -78,7 +78,7 @@ class FluentBadgeExtensionTest extends SapphireTest
             $result = $this->extension->getBadge($this->mockPage);
             $this->assertInstanceOf(DBHTMLText::class, $result);
             $this->assertContains('fluent-badge--invisible', $result->getValue());
-            $this->assertContains('is not visible in this locale', $result->getValue());
+            $this->assertContains('Page has no available content in', $result->getValue());
             $this->assertContains('de_DE', $result->getValue(), 'Badge shows owner locale');
         });
     }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -211,7 +211,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testStatusMessageInherited()
+    public function testStatusMessageUnknown()
     {
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -230,7 +230,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
             $statusMessage = $fields->fieldByName('LocaleStatusMessage');
 
             $this->assertNotNull($fields->fieldByName('LocaleStatusMessage'));
-            $this->assertContains('Content for this page may be inherited', $statusMessage->getContent());
+            $this->assertContains('No content is available for this page', $statusMessage->getContent());
         });
     }
 


### PR DESCRIPTION
# Localisation manager UI improvements / configuration improvements

These changed can be split into separate pull requests and processed individually.

## Configuration changes

New configuration options were added.

### Batch actions configuration

* Fluent menu batch actions are potentially quite destructive and may not be needed in some projects
* added an option to disable this menu (menu is enabled by default)
* following actions are not shown if the menu is disabled batch unlocalise, batch localise, batch unpublish, batch publish, batch archive

### Copy to / from locale configuration

* copy content from one locale to another can be achieved by either action and this may be confusing for the content authors (simplicity over flexibility)
* this new configuration allows the developer to choose which actions are desired
* both actions are enabled by default (previous behaviour)

## Terminology

These change are related to how we name things.

* `isLive` - refers to an object being available on the frontend
* `IsPublished` refers to an object which has a a localised record in its live table

### Features

New features were added.

## Localisation state

* current UI is a little bit confusing as it's mixing multiple concepts together
* concern 1 - where data is available and in which state, this information is mostly useful for operating copy to / from actions
* concern 2 - what is displayed on the frontend
* new UI separates these concerns
* `Draft` column renamed to `Status`
* `Published` column renamed to `Live`
* `Source` column added to reflect where the content is coming from (which locale)

#### Non-versioned UI

* `Status` column shows either Localised or Not localised
* `Source` show the locale which is the source of the content

![Screen Shot 2020-06-23 at 11 24 06 AM](https://user-images.githubusercontent.com/26395487/85344544-1a305480-b544-11ea-9b3d-555ec3c3c639.png)

#### Versioned UI

* `Status` column shows either Draft, Published, Modified or Not localised
* `Source` show the locale which is the source of the content
* `Live` column shows either Yes or No

![Screen Shot 2020-06-23 at 11 22 45 AM](https://user-images.githubusercontent.com/26395487/85344552-20becc00-b544-11ea-886e-d3e6b9e241a4.png)

### Detect modified state

* added `stagesDifferInLocale` which is a Fluent friendly version of `stagesDiffer`

### Badges UI

* badges now only reflect localisation state which makes the UI less confusing (separation of concerns - don't mix versioned state and localisation state)
* any terminology which is related to Versioned state has been removed as the information is represented elsewhere
* new badge states are: localised (has localised record), inherited (inherits from another locale) and unknown (no localised record and no inheritance)
* messages updated accordingly

### copy to draft, copy & publish action configuration

* added an option to enable / disable localise actions (copy to draft, copy & publish), enabled by default
* these actions may not be needed as the same result can be achieved by using localisation manager

### Global template helper for current locale

* current locale object helper method added
* this is useful for situation where locale object is needed in the template for cases like outputting current locale Title or other data

### Publish state fix for multiple actions / areas

* Following actions now reflect the published state based on localised record instead of base record (publish action, information panel, unpublish action, archive action)

### Non-versioned UI improvements

Pushed up Non-versioned UI improvements:

* save action is changed to Localise in case the record is not localised in current locale (edits only)

![Screen Shot 2020-06-29 at 1 54 49 PM](https://user-images.githubusercontent.com/26395487/85965254-32a2e200-ba10-11ea-8cbb-4023f9e3056e.png)

* delete action is changed to Unlocalise in case he record is localised and i's not the last locale

![Screen Shot 2020-06-29 at 1 55 01 PM](https://user-images.githubusercontent.com/26395487/85965262-37679600-ba10-11ea-8426-cc886df76ba5.png)


## Related issues

https://github.com/tractorcow-farm/silverstripe-fluent/issues/621