### PR TITLE
v5: Rename cms publish required config

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -3,7 +3,7 @@ Name: fluentmodel
 ---
 SilverStripe\ORM\DataObject:
   # See FluentExtension
-  cms_publish_required: false
+  cms_localisation_required: false
   frontend_publish_required: true
   # See FluentFilteredExtension
   apply_filtered_locales_to_stage: true

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -1016,6 +1016,12 @@ class FluentExtension extends DataExtension
             return $this->owner->config()->get('frontend_publish_required');
         }
 
+        if ($this->owner->config()->get('cms_publish_required') !== null) {
+            Deprecation::notice('5.0', 'Use cms_localisation_required instead');
+
+            return $this->owner->config()->get('cms_publish_required');
+        }
+
         return $this->owner->config()->get('cms_localisation_required');
     }
 

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -1016,7 +1016,7 @@ class FluentExtension extends DataExtension
             return $this->owner->config()->get('frontend_publish_required');
         }
 
-        return $this->owner->config()->get('cms_publish_required');
+        return $this->owner->config()->get('cms_localisation_required');
     }
 
     /**

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -329,7 +329,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testHomeVisibleOnFrontendBothConfigFalse()
     {
-        Config::modify()->set(DataObject::class, 'cms_publish_required', false);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', false);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
@@ -346,7 +346,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testHomeVisibleOnFrontendOneConfigFalse()
     {
-        Config::modify()->set(DataObject::class, 'cms_publish_required', true);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', true);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
@@ -363,7 +363,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testHomeNotVisibleOnFrontendBothConfigTrue()
     {
-        Config::modify()->set(DataObject::class, 'cms_publish_required', true);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', true);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
@@ -380,7 +380,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testHomeNotVisibleOnFrontendOneConfigTrue()
     {
-        Config::modify()->set(DataObject::class, 'cms_publish_required', false);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', false);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
@@ -397,7 +397,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testHomeVisibleInCMSBothConfigFalse()
     {
-        Config::modify()->set(DataObject::class, 'cms_publish_required', false);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', false);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
@@ -414,7 +414,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testHomeVisibleInCMSOneConfigFalse()
     {
-        Config::modify()->set(DataObject::class, 'cms_publish_required', false);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', false);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
@@ -431,7 +431,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testHomeNotVisibleInCMSBothConfigTrue()
     {
-        Config::modify()->set(DataObject::class, 'cms_publish_required', true);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', true);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
@@ -448,7 +448,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testHomeNotVisibleInCMSOneConfigTrue()
     {
-        Config::modify()->set(DataObject::class, 'cms_publish_required', true);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', true);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
 
         FluentState::singleton()->withState(function (FluentState $newState) {

--- a/tests/php/Model/Delete/Fixtures/LocalisedRecord.php
+++ b/tests/php/Model/Delete/Fixtures/LocalisedRecord.php
@@ -15,7 +15,7 @@ class LocalisedRecord extends DataObject implements TestOnly
 
     private static $frontend_publish_required = false;
 
-    private static $cms_publish_required = false;
+    private static $cms_localisation_required = false;
 
     private static $extensions = [
         FluentExtension::class,


### PR DESCRIPTION
No functional change, it's just always bugged me that I didn't really call this config the correct name. Given that we're moving to a major version, now seems like the time to update the name.

I'm not entirely sold on `cms_localisation_required` either... `backend_localisation_required`, maybe?

This config never required "publishing" for the object to be displayed in the CMS, it required "localisation".

I think the feature is still useful in certain situations. EG: For one of our projects we have a Model that is 100% managed through a 3rd party system (we just consume the data). There is no data fallback allowed for these Models, they must be localised in a Locale to be available. This config means that we can easily hide these Models in all interfaces (Model Admin, Dropdown fields, etc) in Locales where those Models are not available.