### PR TITLE
Wrap middleware state mutations inside state helpers

### DIFF
--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -96,29 +96,31 @@ class DetectLocaleMiddleware implements HTTPMiddleware
      */
     public function process(HTTPRequest $request, callable $delegate)
     {
-        $state = FluentState::singleton();
-        $locale = $state->getLocale();
+        return FluentState::singleton()
+            ->withState(function ($state) use ($delegate, $request) {
+                $locale = $state->getLocale();
 
-        if (!$locale) {
-            $locale = $this->getLocale($request);
-            $state->setLocale($locale);
-        }
+                if (!$locale) {
+                    $locale = $this->getLocale($request);
+                    $state->setLocale($locale);
+                }
 
-        // Validate the user is allowed to access this locale
-        $this->validateAllowedLocale($state);
+                // Validate the user is allowed to access this locale
+                $this->validateAllowedLocale($state);
 
-        if ($locale && $state->getIsFrontend()) {
-            i18n::set_locale($state->getLocale());
-        }
+                if ($locale && $state->getIsFrontend()) {
+                    i18n::set_locale($state->getLocale());
+                }
 
-        // Persist the current locale if it has a value.
-        // Distinguishes null from empty strings in order to unset locales.
-        $newLocale = $state->getLocale();
-        if (!is_null($newLocale)) {
-            $this->setPersistLocale($request, $newLocale);
-        }
+                // Persist the current locale if it has a value.
+                // Distinguishes null from empty strings in order to unset locales.
+                $newLocale = $state->getLocale();
+                if (!is_null($newLocale)) {
+                    $this->setPersistLocale($request, $newLocale);
+                }
 
-        return $delegate($request);
+                return $delegate($request);
+            });
     }
 
     /**

--- a/src/Middleware/InitStateMiddleware.php
+++ b/src/Middleware/InitStateMiddleware.php
@@ -8,7 +8,6 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Environment;
-use SilverStripe\Core\Injector\Injector;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\State\FluentState;
@@ -33,31 +32,30 @@ class InitStateMiddleware implements HTTPMiddleware
 
     public function process(HTTPRequest $request, callable $delegate)
     {
-        $state = FluentState::create();
-        Injector::inst()->registerService($state);
+        return FluentState::singleton()
+            ->withState(function ($state) use ($delegate, $request) {
+                // Detect frontend
+                $isFrontend = $this->getIsFrontend($request);
 
-        // Detect frontend
-        $isFrontend = $this->getIsFrontend($request);
+                // Only set domain mode on the frontend
+                $isDomainMode = $isFrontend ? $this->getIsDomainMode($request) : false;
 
-        // Only set domain mode on the frontend
-        $isDomainMode = $isFrontend ? $this->getIsDomainMode($request) : false;
+                // Don't set domain unless in domain mode
+                $domain = $isDomainMode ? Director::host($request) : null;
+                // Update state
+                $state
+                    ->setIsFrontend($isFrontend)
+                    ->setIsDomainMode($isDomainMode)
+                    ->setDomain($domain);
 
-        // Don't set domain unless in domain mode
-        $domain = $isDomainMode ? Director::host($request) : null;
-
-        // Update state
-        $state
-            ->setIsFrontend($isFrontend)
-            ->setIsDomainMode($isDomainMode)
-            ->setDomain($domain);
-
-        return $delegate($request);
+                return $delegate($request);
+            });
     }
 
     /**
      * Determine whether the website is being viewed from the frontend or not
      *
-     * @param  HTTPRequest $request
+     * @param HTTPRequest $request
      * @return bool
      */
     public function getIsFrontend(HTTPRequest $request)
@@ -83,7 +81,7 @@ class InitStateMiddleware implements HTTPMiddleware
     /**
      * Determine whether the website is running in domain segmentation mode
      *
-     * @param  HTTPRequest $request
+     * @param HTTPRequest $request
      * @return bool
      */
     public function getIsDomainMode(HTTPRequest $request)

--- a/src/State/FluentState.php
+++ b/src/State/FluentState.php
@@ -5,6 +5,7 @@ namespace TractorCow\Fluent\State;
 use InvalidArgumentException;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\i18n\i18n;
 
 /**
  * Stores the current fluent state
@@ -145,11 +146,13 @@ class FluentState
     public function withState(callable $callback)
     {
         $newState = clone $this;
+        $oldLocale = i18n::get_locale(); // Backup locale in case the callback modifies this
         try {
             Injector::inst()->registerService($newState);
             return $callback($newState);
         } finally {
             Injector::inst()->registerService($this);
+            i18n::set_locale($oldLocale);
         }
     }
 }


### PR DESCRIPTION
This will prevent Director::test() mutating the state
Ensure that FluentState::withState() backs up i18n locale also
Fixes #642