### PR TITLE
ENHANCEMENT 404 errors when changing locales will redirect to the home page of the CMS

### DIFF
--- a/_config/routing.yml
+++ b/_config/routing.yml
@@ -13,3 +13,4 @@ SilverStripe\Core\Injector\Injector:
       Middlewares:
         InitStateMiddleware: '%$TractorCow\Fluent\Middleware\InitStateMiddleware'
         DetectLocaleMiddleware: '%$TractorCow\Fluent\Middleware\DetectLocaleMiddleware'
+        LocaleSwitchRedirector: '%$TractorCow\Fluent\Middleware\LocaleSwitchRedirector'

--- a/src/Middleware/LocaleSwitchRedirector.php
+++ b/src/Middleware/LocaleSwitchRedirector.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace TractorCow\Fluent\Middleware;
+
+use SilverStripe\Admin\AdminRootController;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Control\Middleware\HTTPMiddleware;
+use TractorCow\Fluent\Extension\FluentDirectorExtension;
+use TractorCow\Fluent\State\FluentState;
+
+/**
+ * This middleware will safely redirect you to the cms landing page when switching locales,
+ * in case you were viewing a url that does not apply to the new locale.
+ */
+class LocaleSwitchRedirector implements HTTPMiddleware
+{
+    public function process(HTTPRequest $request, callable $delegate)
+    {
+        // Get and capture any possible errors
+        try {
+            $response = $delegate($request);
+        } catch (HTTPResponse_Exception $ex) {
+            $response = $ex->getResponse();
+        }
+
+        // Check if this is a 404 error attempting when switching locales in the CMS
+        $state = FluentState::singleton();
+        if ($response->getStatusCode() === 404
+            && !$state->getIsFrontend()
+            && $this->getParamLocale($request)
+        ) {
+            // Redirect to the CMS home page if the requested page doesn't exist
+            $response = new HTTPResponse();
+            $response->redirect(Controller::join_links(
+                Director::baseURL(),
+                AdminRootController::admin_url()
+            ));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Get locale from the query_param
+     *
+     * @param HTTPRequest $request
+     * @return mixed
+     */
+    protected function getParamLocale(HTTPRequest $request)
+    {
+        $queryParam = FluentDirectorExtension::config()->get('query_param');
+        return (string)($request->param($queryParam) ?: $request->requestVar($queryParam));
+    }
+}


### PR DESCRIPTION
E.g. when viewing a record (that may only be valid in one locale), if you change the locale dropdown, you could sometimes end up on a 404 page.

`That record was not found`

This middleware will detect those errors and safely redirect the user to the main admin page instead.

I've opted not to do this on the frontend because it could interfere with any custom home page routing the dev could have built.