### PR TITLE
NEW: Initial page localisation task (for single language sites import).

### DIFF
--- a/docs/en/migrating-from-single-language.md
+++ b/docs/en/migrating-from-single-language.md
@@ -38,3 +38,27 @@ When you run `dev/build?flush` again, this adds the records to the database if t
 Now your site is broken, cause no pages have been published and added as translated page in your default locale. 
 You can either publish all pages manually or use [publishall](https://docs.silverstripe.org/en/4/developer_guides/debugging/url_variable_tools/#building-and-publishing-urls) to publish all pages in bulk.
 If you run `/admin/pages/publishall` in your browser  your site will be fixed again and you can start adding translated content.  
+
+### Automated tools for localisation
+
+`InitialPageLocalisation` dev task can be used to either only localise or localise & publish your pages.
+This dev task can be run either via CLI or queued as a job if Queued jobs module is installed.
+
+Localise only example
+
+```
+dev/tasks/initial-page-localisation-task
+```
+
+Localise & publish example
+
+```
+dev/tasks/initial-page-localisation-task publish=1
+```
+
+Localisation in batches can be done by using the `limit` option.
+Example below will localise & publish five pages on each run.
+
+```
+dev/tasks/initial-page-localisation-task publish=1&limit=5
+```

--- a/src/Task/InitialPageLocalisationTask.php
+++ b/src/Task/InitialPageLocalisationTask.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace TractorCow\Fluent\Task;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\Versioned\Versioned;
+use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
+use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\State\FluentState;
+
+class InitialPageLocalisationTask extends BuildTask
+{
+    /**
+     * @var string
+     */
+    private static $segment = 'initial-page-localisation-task';
+
+    /**
+     * @var string
+     */
+    protected $title = 'Initial page localisation';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Intended for projects which already have some pages when Fluent module is added.' .
+    ' This dev task will localise / publish all pages in the default locale. Locale setup has to be done before running this task.' .
+    ' Pages which are not published will not be published, only localised. Pages which are already localised will be skipped.';
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function run($request)
+    {
+        $publish = (bool) $request->getVar('publish');
+        $limit = (int) $request->getVar('limit');
+
+        /** @var Locale $globalLocale */
+        $globalLocale = Locale::get()
+            ->filter(['IsGlobalDefault' => 1])
+            ->sort('ID', 'ASC')
+            ->first();
+
+        if (!$globalLocale) {
+            echo 'Please set global locale first!' . PHP_EOL;
+
+            return;
+        }
+
+        $pageIds = FluentState::singleton()->withState(static function (FluentState $state) use ($limit): array {
+            $state->setLocale(null);
+            $pages = SiteTree::get()->sort('ID', 'ASC');
+
+            if ($limit > 0) {
+                $pages = $pages->limit($limit);
+            }
+
+            return $pages->column('ID');
+        });
+
+        $localised = FluentState::singleton()->withState(
+            static function (FluentState $state) use ($globalLocale, $pageIds, $publish): int {
+                $state->setLocale($globalLocale->Locale);
+                $localised = 0;
+
+                foreach ($pageIds as $pageId) {
+                    /** @var SiteTree|FluentSiteTreeExtension $page */
+                    $page = SiteTree::get()->byID($pageId);
+
+                    if ($page->isDraftedInLocale()) {
+                        continue;
+                    }
+
+                    $page->writeToStage(Versioned::DRAFT);
+                    $localised += 1;
+
+                    if (!$publish) {
+                        continue;
+                    }
+
+                    // Check if the base record was published - if not then we don't need to publish
+                    // as this would leak draft content, we only want to publish pages which were published
+                    // before Fluent module was added
+                    $pageId = $page->ID;
+                    $isBaseRecordPublished = FluentState::singleton()->withState(
+                        static function (FluentState $state) use ($pageId): bool {
+                            $state->setLocale(null);
+                            $page = SiteTree::get_by_id($pageId);
+
+                            if ($page === null) {
+                                return false;
+                            }
+
+                            return $page->isPublished();
+                        }
+                    );
+
+                    if (!$isBaseRecordPublished) {
+                        continue;
+                    }
+
+                    $page->publishRecursive();
+                }
+
+                return $localised;
+            }
+        );
+
+        echo sprintf('Localised %d pages.', $localised) . PHP_EOL;
+    }
+}

--- a/tests/php/Task/InitialPageLocalisationTaskTest.php
+++ b/tests/php/Task/InitialPageLocalisationTaskTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Task;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ValidationException;
+use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
+use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\State\FluentState;
+use TractorCow\Fluent\Task\InitialPageLocalisationTask;
+
+class InitialPageLocalisationTaskTest extends SapphireTest
+{
+    protected static $fixture_file = 'InitialPageLocalisationTaskTest.yml';
+
+    protected function setUp(): void
+    {
+        FluentState::singleton()->withState(function (FluentState $state): void {
+            // We don't want to localise pages yet - create only base records
+            $state->setLocale(null);
+
+            parent::setUp();
+        });
+    }
+
+    /**
+     * @param bool $publish
+     * @param int $limit
+     * @param array $localised
+     * @param array $published
+     * @dataProvider publishStateProvider
+     */
+    public function testInitialPageLocalisation(bool $publish, int $limit, array $localised, array $published): void
+    {
+        // Check base records
+        $pages = FluentState::singleton()->withState(function (FluentState $state): array {
+            $state->setLocale(null);
+
+            // Publish some base records (too much effort to set up via fixture)
+            $pagesToPublish = [
+                'page1',
+                'page2',
+            ];
+
+            foreach ($pagesToPublish as $identifier) {
+                /** @var SiteTree $page */
+                $page = $this->objFromFixture(SiteTree::class, $identifier);
+                $page->publishRecursive();
+            }
+
+            return SiteTree::get()
+                ->sort('Title', 'ASC')
+                ->column('Title');
+        });
+
+        $allPages = [
+            'Page1',
+            'Page2',
+            'Page3',
+            'Page4',
+        ];
+
+        $this->assertEquals($allPages, $pages);
+
+        // Check localised records (should be empty)
+        $pages = $this->getLocalisedPages();
+        $this->assertCount(0, $pages);
+
+        $getParams = [
+            'publish' => $publish,
+            'limit' => $limit,
+        ];
+
+        // Localise pages
+        InitialPageLocalisationTask::singleton()->run(new HTTPRequest('GET', '/', $getParams));
+
+        // Check localised records (should have all pages now)
+        $pages = $this->getLocalisedPages();
+        $this->assertEquals($localised, $pages);
+
+        // Check published state
+        $pages = FluentState::singleton()->withState(function (FluentState $state) use ($publish): array {
+            $state->setLocale('en_NZ');
+            $pages = SiteTree::get()->sort('Title', 'ASC');
+            $publishedPages = [];
+
+            /** @var SiteTree|FluentSiteTreeExtension $page */
+            foreach ($pages as $page) {
+                if (!$page->isDraftedInLocale()) {
+                    continue;
+                }
+
+                if (!$page->isPublishedInLocale()) {
+                    continue;
+                }
+
+                $publishedPages[] = $page->Title;
+            }
+
+            return $publishedPages;
+        });
+
+        $this->assertEquals($published, $pages);
+    }
+
+    public function publishStateProvider(): array
+    {
+        return [
+            [
+                false,
+                0,
+                [
+                    'Page1',
+                    'Page2',
+                    'Page3',
+                    'Page4',
+                ],
+                [],
+            ],
+            [
+                true,
+                0,
+                [
+                    'Page1',
+                    'Page2',
+                    'Page3',
+                    'Page4',
+                ],
+                [
+                    'Page1',
+                    'Page2',
+                ],
+            ],
+            [
+                false,
+                1,
+                [
+                    'Page1',
+                ],
+                [],
+            ],
+            [
+                true,
+                1,
+                [
+                    'Page1',
+                ],
+                [
+                    'Page1',
+                ],
+            ],
+            [
+                false,
+                2,
+                [
+                    'Page1',
+                    'Page2',
+                ],
+                [],
+            ],
+            [
+                true,
+                2,
+                [
+                    'Page1',
+                    'Page2',
+                ],
+                [
+                    'Page1',
+                    'Page2',
+                ],
+            ],
+        ];
+    }
+
+    private function getLocalisedPages(): array
+    {
+        return FluentState::singleton()->withState(static function (FluentState $state): array {
+            $state->setLocale('en_NZ');
+
+            $pages = SiteTree::get()->sort('Title', 'ASC');
+            $titles = [];
+
+            /** @var SiteTree|FluentSiteTreeExtension $page */
+            foreach ($pages as $page) {
+                if (!$page->isDraftedInLocale()) {
+                    continue;
+                }
+
+                $titles[] = $page->Title;
+            }
+
+            return $titles;
+        });
+    }
+}

--- a/tests/php/Task/InitialPageLocalisationTaskTest.yml
+++ b/tests/php/Task/InitialPageLocalisationTaskTest.yml
@@ -1,0 +1,24 @@
+TractorCow\Fluent\Model\Locale:
+  en_NZ:
+    Locale: en_NZ
+    URLSegment: nz
+    IsGlobalDefault: 1
+  en_AU:
+    Locale: en_AU
+    URLSegment: au
+    Fallbacks:
+      - =>TractorCow\Fluent\Model\Locale.en_NZ
+
+SilverStripe\CMS\Model\SiteTree:
+  page1:
+    Title: Page1
+    URLSegment: page1
+  page2:
+    Title: Page2
+    URLSegment: page2
+  page3:
+    Title: Page3
+    URLSegment: page3
+  page4:
+    Title: Page4
+    URLSegment: page4


### PR DESCRIPTION
# NEW: Initial page localisation task (for single language sites import)

Migration from a single language for medium and large sites were lacking support and this PR addresses that.

* added a dev task which allows pages to be localised & published in bulk
* this dev task can be run via CLI and can be wrapped inside a job or hooked up to Cron
* documentation updated accordingly

## Related issues

https://github.com/tractorcow-farm/silverstripe-fluent/issues/672