### PR TITLE
BUG: Versioned related fixes

### DIFF
--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -5,6 +5,10 @@ SilverStripe\Admin\LeftAndMain:
   extensions:
     FluentLeftAndMainExtension: TractorCow\Fluent\Extension\FluentLeftAndMainExtension
 
+SilverStripe\CMS\Controllers\CMSMain:
+  extensions:
+    FluentLeftAndMainExtension: TractorCow\Fluent\Extension\FluentCMSMainExtension
+
 SilverStripe\Versioned\ChangeSetItem:
   extensions:
     FluentChangesExtension: TractorCow\Fluent\Extension\FluentChangesExtension

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -356,3 +356,25 @@ Knows issues are:
 * incorrect detection of end of word
 * incorrect detection of end of line
 * use of functions which are not multi-byte safe
+
+## CMS UI
+
+There are some optional components which can be enabled / disabled.
+
+### Page edit form action buttons
+
+Using the page edit form buttons to localise pages may not work properly in all situations, hence the following configuration (enabled by default):
+
+```yml
+SilverStripe\CMS\Model\SiteTree:
+  localise_actions_enabled: true
+```
+
+If it's disabled, the `Copy to draft` and `Copy & publish` buttons will not be displayed.
+Users are expected to use the `Localisation` manager tab in the page edit form instead in such case.
+
+#### When should I disable this setting?
+
+In case your setup contains multiple top level locales (i.e. locales which have no fallbacks) you may need to review this setting.
+Using the action buttons to localise pages may result in unpredictable results as the content for the newly localised page will be taken from the base record as no fallback locale exists.
+This may still be fine in some cases, for example when migrating from a single language site.

--- a/src/Extension/FluentCMSMainExtension.php
+++ b/src/Extension/FluentCMSMainExtension.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace TractorCow\Fluent\Extension;
+
+use SilverStripe\CMS\Controllers\CMSMain;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\Form;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Versioned\Versioned;
+use TractorCow\Fluent\Forms\CopyLocaleAction;
+
+/**
+ * Custom handling of save & publish actions
+ * this is needed to ensure correct localised version records are created
+ * Currently, the default save / publish actions call @see Versioned::writeWithoutVersion() which breaks
+ * the Fluent functionality
+ * This extension injects the code which ensures the correct localisation is executed before the default action
+ *
+ * @see FluentSiteTreeExtension::updateSavePublishActions()
+ * @see CopyLocaleAction::handleAction()
+ * @property CMSMain $owner
+ */
+class FluentCMSMainExtension extends Extension
+{
+    /**
+     * @var array
+     */
+    private static $allowed_actions = [
+        'save_localised_copy',
+        'publish_localised_copy',
+    ];
+
+    /**
+     * @param array $data
+     * @param Form $form
+     * @return HTTPResponse
+     * @throws HTTPResponse_Exception
+     * @throws ValidationException
+     */
+    public function save_localised_copy($data, $form)
+    {
+        $owner = $this->owner;
+
+        /** @var SiteTree $record */
+        $record = $this->getRecordForLocalisedAction($data, $form);
+
+        if ($record === null) {
+            return $owner->save($data, $form);
+        }
+
+        // Check edit permissions
+        if (!$record->canEdit()) {
+            return $owner->save($data, $form);
+        }
+
+        // Localise record (this ensures correct localised version is created)
+        $record->writeToStage(Versioned::DRAFT);
+
+        return $owner->save($data, $form);
+    }
+
+    /**
+     * @param array $data
+     * @param Form $form
+     * @return HTTPResponse
+     * @throws HTTPResponse_Exception
+     * @throws ValidationException
+     */
+    public function publish_localised_copy($data, $form)
+    {
+        $owner = $this->owner;
+
+        /** @var SiteTree $record */
+        $record = $this->getRecordForLocalisedAction($data, $form);
+
+        if ($record === null) {
+            return $owner->publish($data, $form);
+        }
+
+        // Check edit permissions
+        if (!$record->canEdit()) {
+            return $owner->publish($data, $form);
+        }
+
+        // Check publishing permissions
+        if (!$record->canPublish()) {
+            return $owner->publish($data, $form);
+        }
+
+        // Localise record (this ensures correct localised version is created)
+        $record->writeToStage(Versioned::DRAFT);
+
+        return $owner->publish($data, $form);
+    }
+
+    /**
+     * @param $data
+     * @param $form
+     * @return DataObject|null
+     */
+    protected function getRecordForLocalisedAction($data, $form): ?DataObject
+    {
+        $id = (int) $data['ID'];
+        $className = $this->owner->config()->get('tree_class');
+
+        if (!$id || !$className) {
+            // Invalid inputs
+            return null;
+        }
+
+        $singleton = DataObject::singleton($className);
+
+        if (!$singleton->hasExtension(FluentVersionedExtension::class)) {
+            // Class not localised with versions
+            return null;
+        }
+
+        if (!$singleton->config()->get('localise_actions_enabled')) {
+            // Feature not enabled
+            return null;
+        }
+
+        /** @var DataObject|FluentVersionedExtension $record */
+        $record = DataObject::get_by_id($className, $id);
+
+        if ($record === null) {
+            // No record
+            return null;
+        }
+
+        if ($record->isDraftedInLocale()) {
+            // Feature not active, record already localised
+            return null;
+        }
+
+        return $record;
+    }
+}

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -43,6 +43,15 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     private static $locale_published_status_message = true;
 
     /**
+     * Enable localise actions (copy to draft and copy & publish actions)
+     * these actions can be used to localise page content directly via main page actions
+     *
+     * @config
+     * @var bool
+     */
+    private static $localise_actions_enabled = true;
+
+    /**
      * Add alternate links to metatags
      *
      * @param string &$tags
@@ -206,13 +215,9 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
             return;
         }
 
-        // Update information panel (shows published state)
+        $this->updateSavePublishActions($actions);
         $this->updateInformationPanel($actions);
-
-        // restore action needs to be removed if current locale was never archived
         $this->updateRestoreAction($actions);
-
-        // Add extra fluent menu
         $this->updateFluentActions($actions, $this->owner);
     }
 
@@ -357,6 +362,78 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     }
 
     /**
+     * Update SiteTree specific save/publish actions
+     *
+     * @param FieldList $actions
+     */
+    protected function updateSavePublishActions(FieldList $actions)
+    {
+        $owner = $this->owner;
+
+        if (!$owner->config()->get('localise_actions_enabled')) {
+            return;
+        }
+
+        if (!$owner->isInDB()) {
+            return;
+        }
+
+        // There's no need to update actions in these ways if the Page has previously been drafted in this Locale.
+        if ($owner->isDraftedInLocale()) {
+            return;
+        }
+
+        // Actions from the base record may not be available because the base record may be considered not in draft state
+        // due to localisation rules
+        $baseActions = FluentState::singleton()->withState(function (FluentState $state) {
+            $state->setLocale(null);
+
+            return $this->owner->getCMSActions();
+        });
+
+        /** @var CompositeField $baseMajorActions */
+        $baseMajorActions = $baseActions->fieldByName('MajorActions');
+        /** @var CompositeField $majorActions */
+        $majorActions = $actions->fieldByName('MajorActions');
+
+        // If another extension has removed this CompositeField then we don't need to update them.
+        if ($baseMajorActions === null || $majorActions === null) {
+            return;
+        }
+
+        $actionSave = $baseMajorActions->getChildren()->fieldByName('action_save');
+        $actionPublish = $baseMajorActions->getChildren()->fieldByName('action_publish');
+        $actionsToAdd = [];
+
+        // Make sure no other extensions have removed this field.
+        if ($actionSave !== null) {
+            $actionSave->addExtraClass('btn-primary font-icon-translatable');
+            $actionSave->setTitle(_t(__CLASS__ . '.LOCALECOPYTODRAFT', 'Copy to draft'));
+            $actionSave->removeExtraClass('btn-outline-primary font-icon-tick');
+            // Override action name as some additional processing is needed
+            $actionSave->setName('action_save_localised_copy');
+            $actionsToAdd[] = $actionSave;
+        }
+
+        // Make sure no other extensions have removed this field.
+        if ($actionPublish !== null) {
+            $actionPublish->addExtraClass('btn-primary font-icon-rocket');
+            $actionPublish->removeExtraClass('btn-outline-primary font-icon-tick');
+            $actionPublish->setTitle(_t(__CLASS__ . '.LOCALECOPYANDPUBLISH', 'Copy & publish'));
+            // Override action name as some additional processing is needed
+            $actionPublish->setName('action_publish_localised_copy');
+            $actionsToAdd[] = $actionPublish;
+        }
+
+        $actionsToAdd = array_reverse($actionsToAdd);
+
+        // Add customised base actions to actions (at the start of the set)
+        foreach ($actionsToAdd as $action) {
+            $majorActions->unshift($action);
+        }
+    }
+
+    /**
      * Restore action needs to be removed if there is no version to revert to
      *
      * @param FieldList $actions
@@ -365,11 +442,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     {
         $owner = $this->owner;
 
-        if ($owner->existsInLocale()) {
-            return;
-        }
-
-        if ($owner->hasArchiveInLocale()) {
+        if (!$owner->existsInLocale() && $owner->hasArchiveInLocale()) {
             return;
         }
 
@@ -377,7 +450,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     }
 
     /**
-     * Information panel show published state of a base record by default
+     * Information panel shows published state of a base record by default
      * this overrides the display with the published state of the localised record
      *
      * @param FieldList $actions

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -377,7 +377,7 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
      */
     public function stagesDifferInLocale($locale = null): bool
     {
-        /** @var DataObject|Versioned|FluentExtension $record */
+        /** @var DataObject|Versioned|FluentExtension|FluentVersionedExtension $record */
         $record = $this->owner;
         $id = $record->ID ?: $record->OldID;
         $class = get_class($record);
@@ -390,6 +390,17 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
         // Need to check that it has stages and is not new
         if (!$id || !$record->hasStages()) {
             return false;
+        }
+
+        if (!$record->isDraftedInLocale()) {
+            // Record is not localised so there is nothing to check
+            // This is because Localised version records can not be inherited from other locales via the fallbacks
+            return false;
+        }
+
+        if (!$record->isPublishedInLocale()) {
+            // Record is drafted but not published so we know the stages are different
+            return true;
         }
 
         $locale = $locale ?: ($this->getRecordLocale() ? $this->getRecordLocale()->Locale : null);


### PR DESCRIPTION
# Versioned related fixes

Impacted versions: `5.x-dev`

## Details

* These are follow up changes to https://github.com/tractorcow-farm/silverstripe-fluent/pull/639
* Stages differ in locale did not cover all cases correctly, this change corrects the behaviour and increases unit test coverage
* Restore action display corrected (Restore action is displayed only when it's relevant)
* Copy-to localise buttons brought back (they were removed in https://github.com/tractorcow-farm/silverstripe-fluent/pull/639 but they still have valid use cases, feedback given in https://github.com/tractorcow-farm/silverstripe-fluent/pull/669)

These buttons are now back and they can be turned on and off:

![Screen Shot 2021-02-09 at 8 49 08 AM](https://user-images.githubusercontent.com/26395487/107306459-c5007d80-6ae9-11eb-81bb-de85d940122a.png)
