### PR TITLE
NEW: Clickable links on page info for localisation tab.

### DIFF
--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -622,7 +622,8 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
                 $recordLocale = $object->RecordLocale();
                 $locale = $recordLocale->getLocale();
                 $localeLink = Controller::join_links($url, '?l=' . $locale);
-                $localeTitle = $recordLocale->getTitle();
+                $localeTitle = Convert::raw2xml($recordLocale->getTitle());
+
                 $render = sprintf('<a href="%s" target="_top">%s</a>', $localeLink, $localeTitle);
 
                 return DBField::create_field('HTMLVarchar', $render);

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -13,6 +13,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\Tab;
+use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\SSViewer;
@@ -577,5 +578,33 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     public function actionComplete($form, $message)
     {
         return null;
+    }
+
+    /**
+     * @param $summaryColumns
+     * @see FluentExtension::updateFluentCMSFields()
+     */
+    public function updateLocalisationTabColumns(&$summaryColumns)
+    {
+        parent::updateLocalisationTabColumns($summaryColumns);
+
+        $summaryColumns['Title'] = [
+            'title' => 'Title',
+            'callback' => function (Locale $object) {
+                if (!$object->RecordLocale()) {
+                    return ;
+                }
+
+                $query_param = '?l=' . $object->RecordLocale()->getLocale();
+                $locale = $object->RecordLocale()->getTitle();
+
+                $baseURL = $_SERVER['REQUEST_URI'];
+                $baseURL = preg_replace('/\?.*/', '', $baseURL);
+
+                $render = sprintf('<a href="%s%s" target="_top">%s</a>', $baseURL, $query_param, $locale);
+
+                return DBField::create_field('HTMLVarchar', $render);
+            }
+        ];
     }
 }

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -8,6 +8,7 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Convert;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -607,7 +607,10 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
             return;
         }
 
+        // This is to get URL only, getVars are not part of the URL
         $url = $request->getURL();
+        // Pass getVars separately so we can process them later
+        $params = $request->getVars();
 
         if (!$url) {
             return;
@@ -615,16 +618,16 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
 
         $summaryColumns['Title'] = [
             'title' => 'Title',
-            'callback' => function (Locale $object) use ($url) {
+            'callback' => function (Locale $object) use ($url, $params) {
                 if (!$object->RecordLocale()) {
                     return;
                 }
 
                 $recordLocale = $object->RecordLocale();
                 $locale = $recordLocale->getLocale();
-                $localeLink = Controller::join_links($url, '?l=' . $locale);
+                $params['l'] = $locale;
+                $localeLink = Controller::join_links($url, '?' . http_build_query($params));
                 $localeTitle = Convert::raw2xml($recordLocale->getTitle());
-
                 $render = sprintf('<a href="%s" target="_top">%s</a>', $localeLink, $localeTitle);
 
                 return DBField::create_field('HTMLVarchar', $render);


### PR DESCRIPTION
# Clickable links on page info for localisation tab

Augment Localisation tab with clickable locale links to allow easy navigation between page localisations.

This feature is applied to only page via `FluentSiteTreeExtension`.

## Preview

![Screen Shot 2021-02-26 at 3 05 02 PM](https://user-images.githubusercontent.com/26395487/109244787-33f90880-7844-11eb-9773-f58c427cab52.png)
