### PR TITLE
Bugfix for version history viewer

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -791,7 +791,7 @@ SQL;
 
         $subSelect
             ->addInnerJoin(
-                sprintf('"%s"', $localisedVersionTable),
+                sprintf('%s', $localisedVersionTable),
                 sprintf(
                     '"%1$s"."RecordID" = "%2$s"."RecordID" AND "%1$s"."Version" = "%2$s"."Version"',
                     $alias,


### PR DESCRIPTION
When you navigate to version history viewer you get an exception from the MySQL query as `$localisedVersionTable` is a string that looks like `"SiteTree_Localised_Versions"` which means it currently then becomes `""SiteTree_Localised_Versions""`