### PR TITLE
update manipulation to skip base table translate fields

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,6 @@ localisations, or being a part of the contributing team, please see
  * [Scenarios](docs/en/scenarios.md)
  * [Localised copy](docs/en/localised-copy.md)
  * [Migrating from Translatable](docs/en/migrating-from-translatable.md)
- * [Changelogs](CHANGELOG.md)
 
 ## Translations
 

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -12,6 +12,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\GridField\GridField_ActionMenuItem;
 use SilverStripe\Forms\GridField\GridFieldConfig;
+use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
@@ -593,7 +594,8 @@ class FluentExtension extends DataExtension
         }
 
         $defaultLocaleObj = Locale::getDefault();
-        $defaultLocale = $defaultLocaleObj ? $defaultLocaleObj->getLocale() : i18n::config()->get('default_locale');
+        $defaultLocale    = $defaultLocaleObj ? $defaultLocaleObj->getLocale() : i18n::config()->get('default_locale');
+        $notDefaultLocale = $locale->getLocale() !== $defaultLocale;
 
         // Get all tables to translate fields for, and their respective field names
         $includedTables = $this->getLocalisedTables();
@@ -607,9 +609,9 @@ class FluentExtension extends DataExtension
                 $locale
             );
 
-            // Remove localised fields from base table if the editing locale is
+            // Remove localised fields from base tables if the editing locale is
             // not the global default locale
-            if ($locale->getLocale() !== $defaultLocale) {
+            if ($notDefaultLocale) {
                 foreach ($localisedFields as $localisedField) {
                     unset($manipulation[$table]['fields'][$localisedField]);
                 }

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -592,6 +592,9 @@ class FluentExtension extends DataExtension
             return;
         }
 
+        $defaultLocaleObj = Locale::getDefault();
+        $defaultLocale = $defaultLocaleObj ? $defaultLocaleObj->getLocale() : i18n::config()->get('default_locale');
+
         // Get all tables to translate fields for, and their respective field names
         $includedTables = $this->getLocalisedTables();
         foreach ($includedTables as $table => $localisedFields) {
@@ -603,15 +606,13 @@ class FluentExtension extends DataExtension
                 $localisedFields,
                 $locale
             );
-        }
 
-        // Remove localised fields from base table if the editing locale is not the global default locale
-        $defaultLocaleObj = Locale::getDefault();
-        $defaultLocale = $defaultLocaleObj ? $defaultLocaleObj->getLocale() : i18n::config()->get('default_locale');
-
-        if ($locale->getLocale() !== $defaultLocale) {
-            foreach ($localisedFields as $localisedField) {
-                unset($manipulation[$table]['fields'][$localisedField]);
+            // Remove localised fields from base table if the editing locale is
+            // not the global default locale
+            if ($locale->getLocale() !== $defaultLocale) {
+                foreach ($localisedFields as $localisedField) {
+                    unset($manipulation[$table]['fields'][$localisedField]);
+                }
             }
         }
     }

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -604,6 +604,16 @@ class FluentExtension extends DataExtension
                 $locale
             );
         }
+
+        // Remove localised fields from base table if the editing locale is not the global default locale
+        $defaultLocaleObj = Locale::getDefault();
+        $defaultLocale = $defaultLocaleObj ? $defaultLocaleObj->getLocale() : i18n::config()->get('default_locale');
+
+        if ($locale->getLocale() !== $defaultLocale) {
+            foreach ($localisedFields as $localisedField) {
+                unset($manipulation[$table]['fields'][$localisedField]);
+            }
+        }
     }
 
     /**

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -21,10 +21,13 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\ManyManyList;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 use Symbiote\GridFieldExtensions\GridFieldAddNewInlineButton;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
+use TractorCow\Fluent\Control\LocaleAdmin;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Extension\Traits\FluentObjectTrait;
 use TractorCow\Fluent\State\FluentState;
@@ -625,5 +628,66 @@ class Locale extends DataObject implements PermissionProvider
             ];
         }
         return $permissions;
+    }
+
+
+    /**
+     * @param Member $member
+     * @return boolean
+     */
+    public function canView($member = null)
+    {
+        $extended = $this->extendedCan(__FUNCTION__, $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+        return Permission::check('CMS_ACCESS', 'any', $member);
+    }
+
+    /**
+     * @param Member $member
+     * @return boolean
+     */
+    public function canEdit($member = null)
+    {
+        $extended = $this->extendedCan(__FUNCTION__, $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        // Access locale admin permission
+        return LocaleAdmin::singleton()->canView($member);
+    }
+
+    /**
+     * @param Member $member
+     * @return boolean
+     */
+    public function canDelete($member = null)
+    {
+        $extended = $this->extendedCan(__FUNCTION__, $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        // Access locale admin permission
+        return LocaleAdmin::singleton()->canView($member);
+    }
+
+    /**
+     * @param Member $member
+     * @param array $context Additional context-specific data which might
+     * affect whether (or where) this object could be created.
+     * @return boolean
+     */
+    public function canCreate($member = null, $context = [])
+    {
+        $extended = $this->extendedCan(__FUNCTION__, $member, $context);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        // Access locale admin permission
+        return LocaleAdmin::singleton()->canView($member);
     }
 }


### PR DESCRIPTION
 ...if editing in non-default-locale.

ref: https://github.com/tractorcow-farm/silverstripe-fluent/issues/702

p.s.
A build failure happens for php-7.2 (PGSQL), but it seems unrelated since it happens for the original branch too.
original 5.0 branch failure: https://travis-ci.com/github/pine3ree/silverstripe-fluent/builds/224071758

kind regards