### PR TITLE
BUG: GridField buttons UI improvements for versioned models.

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -189,6 +189,15 @@ class FluentExtension extends DataExtension
     private static $localised_copy = [];
 
     /**
+     * Enable localise actions (copy to draft, copy & publish and Localise actions)
+     * these actions can be used to localise page content directly via main page actions
+     *
+     * @config
+     * @var bool
+     */
+    private static $localise_actions_enabled = true;
+
+    /**
      * Cache of localised fields for this model
      */
     protected $localisedFields = [];


### PR DESCRIPTION
# GridField buttons UI improvements for versioned models.

* `localise_actions_enabled` setting moved down to FluentExtension and now applied to all buttons UI cases (model, versioned model, site tree model)
* information panel enhancements moved to `FluentAdminTrait` so it's shared with versioned model
* save and delete action UI enhancements now also apply to versioned models

![Screen Shot 2021-05-04 at 8 51 43 AM](https://user-images.githubusercontent.com/26395487/116933027-1b2f2800-acb7-11eb-8d25-fbce5ec840f6.png)