### PR TITLE
NEW: Locale fallback configuration enhancement.

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -4,7 +4,7 @@ Name: fluentmodel
 SilverStripe\ORM\DataObject:
   # See FluentExtension
   cms_localisation_required: any
-  frontend_publish_required: none
+  frontend_publish_required: fallback
   # See FluentFilteredExtension
   apply_filtered_locales_to_stage: true
   # See FluentIsolatedExtension

--- a/_config/model.yml
+++ b/_config/model.yml
@@ -3,8 +3,8 @@ Name: fluentmodel
 ---
 SilverStripe\ORM\DataObject:
   # See FluentExtension
-  cms_localisation_required: false
-  frontend_publish_required: true
+  cms_localisation_required: any
+  frontend_publish_required: none
   # See FluentFilteredExtension
   apply_filtered_locales_to_stage: true
   # See FluentIsolatedExtension
@@ -12,4 +12,4 @@ SilverStripe\ORM\DataObject:
 
 # Prevent duplicate siteconfigs when localised
 SilverStripe\SiteConfig\SiteConfig:
-  frontend_publish_required: false
+  frontend_publish_required: any

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -209,13 +209,13 @@ We can change this behaviour by updating the `frontend_publish_required` configu
 Globally:
 ```yaml
 TractorCow\Fluent\Extension\FluentExtension:
-  frontend_publish_required: false
+  frontend_publish_required: any
 ```
 
 For a specific DataObject:
 ```yaml
 MySite\Model\MyModel:
-  frontend_publish_required: false
+  frontend_publish_required: any
 ```
 
 **Note:** If you are applying this via an `Extension`, be sure to apply it after the `FluentExtension`.

--- a/docs/en/deletion-policies.md
+++ b/docs/en/deletion-policies.md
@@ -26,9 +26,9 @@ This policy will delete the localisation for the record in the current locale.
 E.g. if you have a locale in both EN and CN, pressing delete in the CN locale
 will delete only that locale, but not the EN (or base) record.
 
-Note that if you have disabled `frontend_publish_required` config, then the record
-will still be available in that locale, but will instead fall back to the failover
-locale instead.
+Note that if you have set `frontend_publish_required` config to `fallback` or `any`, then the record
+will still be available in that locale, but will instead fall back to the failover instead
+(depending on your configuration).
 
 This policy is applied only to records with `FluentExtension` applied.
 

--- a/docs/en/scenarios.md
+++ b/docs/en/scenarios.md
@@ -62,13 +62,13 @@ By default, DataObjects must be Localised for them to display on the frontend (E
 **Globally:**
 ```yaml
 TractorCow\Fluent\Extension\FluentExtension:
-  frontend_publish_required: false
+  frontend_publish_required: any
 ```
 
 **For a specific DataObject:**
 ```yaml
 MySite\Model\MyModel:
-  frontend_publish_required: false
+  frontend_publish_required: any
 ```
 
 #### Result

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -66,6 +66,24 @@ class FluentExtension extends DataExtension
     const TRANSLATE_NONE = 'none';
 
     /**
+     * Content inheritance - content will be served from the following sources in this order:
+     * current locale
+     */
+    const INHERITANCE_MODE_NONE = 'none';
+
+    /**
+     * Content inheritance - content will be served from the following sources in this order:
+     * current locale, fallback locale
+     */
+    const INHERITANCE_MODE_FALLBACK = 'fallback';
+
+    /**
+     * Content inheritance - content will be served from the following sources in this order:
+     * current locale, fallback locale, base record
+     */
+    const INHERITANCE_MODE_ANY = 'any';
+
+    /**
      * DB fields to be used added in when creating a localised version of the owner's table
      *
      * @config
@@ -469,11 +487,24 @@ class FluentExtension extends DataExtension
             }
         }
 
-        // On frontend only show if published in this specific locale
-        if ($this->requireSavedInLocale()) {
+        // Resolve content inheritance (this drives what content is shown)
+        $inheritanceMode = $this->getInheritanceMode();
+        if ($inheritanceMode === self::INHERITANCE_MODE_NONE) {
             $joinAlias = $this->getLocalisedTable($this->owner->baseTable(), $locale->Locale);
-            $where = "\"{$joinAlias}\".\"ID\" IS NOT NULL";
+            $where = sprintf('"%s"."ID" IS NOT NULL', $joinAlias);
             $query->addWhereAny($where);
+        } elseif ($inheritanceMode === self::INHERITANCE_MODE_FALLBACK) {
+            $conditions = [];
+
+            foreach ($this->owner->getLocalisedTables() as $table => $fields) {
+                foreach ($locale->getChain() as $joinLocale) {
+                    $joinAlias = $this->getLocalisedTable($table, $joinLocale->Locale);
+
+                    $conditions[] = sprintf('"%s"."ID" IS NOT NULL', $joinAlias);
+                }
+            }
+
+            $query->addWhereAny($conditions);
         }
 
         // Add the "source locale", which the content exists in up the chain
@@ -1021,21 +1052,25 @@ class FluentExtension extends DataExtension
     /**
      * Require that this record is saved in the given locale for it to be visible
      *
-     * @return bool
+     * @return string
      */
-    protected function requireSavedInLocale()
+    protected function getInheritanceMode(): string
     {
-        if (FluentState::singleton()->getIsFrontend()) {
-            return $this->owner->config()->get('frontend_publish_required');
+        $config = $this->owner->config();
+        $inheritanceMode = FluentState::singleton()->getIsFrontend()
+            ? $config->get('frontend_publish_required')
+            : $config->get('cms_localisation_required');
+
+        if (!in_array($inheritanceMode, [
+            self::INHERITANCE_MODE_NONE,
+            self::INHERITANCE_MODE_FALLBACK,
+            self::INHERITANCE_MODE_ANY,
+        ])) {
+            // Default mode
+            $inheritanceMode = self::INHERITANCE_MODE_ANY;
         }
 
-        if ($this->owner->config()->get('cms_publish_required') !== null) {
-            Deprecation::notice('5.0', 'Use cms_localisation_required instead');
-
-            return $this->owner->config()->get('cms_publish_required');
-        }
-
-        return $this->owner->config()->get('cms_localisation_required');
+        return $inheritanceMode;
     }
 
     /**

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -256,7 +256,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     {
         $owner = $this->owner;
 
-        if ($owner->config()->get('frontend_publish_required') === FluentExtension::INHERITANCE_MODE_NONE) {
+        if ($owner->config()->get('frontend_publish_required') === FluentExtension::INHERITANCE_MODE_EXACT) {
             // If publishing is required, then we can just check whether or not this locale has been published.
             if (!$this->isPublishedInLocale()) {
                 return _t(

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -256,7 +256,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     {
         $owner = $this->owner;
 
-        if ($owner->config()->get('frontend_publish_required')) {
+        if ($owner->config()->get('frontend_publish_required') === FluentExtension::INHERITANCE_MODE_NONE) {
             // If publishing is required, then we can just check whether or not this locale has been published.
             if (!$this->isPublishedInLocale()) {
                 return _t(

--- a/src/Model/RecordLocale.php
+++ b/src/Model/RecordLocale.php
@@ -279,7 +279,7 @@ class RecordLocale extends ViewableData
         }
 
         // If frontend publishing is not required for localisation, no further checks required
-        if (!$inLocale && $record->config()->get('frontend_publish_required') !== FluentExtension::INHERITANCE_MODE_NONE) {
+        if (!$inLocale && $record->config()->get('frontend_publish_required') !== FluentExtension::INHERITANCE_MODE_EXACT) {
             return true;
         }
 

--- a/src/Model/RecordLocale.php
+++ b/src/Model/RecordLocale.php
@@ -279,7 +279,7 @@ class RecordLocale extends ViewableData
         }
 
         // If frontend publishing is not required for localisation, no further checks required
-        if (!$inLocale && !$record->config()->get('frontend_publish_required')) {
+        if (!$inLocale && $record->config()->get('frontend_publish_required') !== FluentExtension::INHERITANCE_MODE_NONE) {
             return true;
         }
 

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -204,7 +204,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
             $page = $this->objFromFixture(Page::class, 'staff');
             $page->config()
                 ->set('locale_published_status_message', true)
-                ->set('frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
+                ->set('frontend_publish_required', FluentExtension::INHERITANCE_MODE_EXACT);
 
             $fields = $page->getCMSFields();
 
@@ -352,7 +352,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testHomeVisibleOnFrontendOneConfigAny()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_EXACT);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_ANY);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
@@ -367,10 +367,10 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeNotVisibleOnFrontendBothConfigNone()
+    public function testHomeNotVisibleOnFrontendBothConfigExact()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_NONE);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_EXACT);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_EXACT);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -384,10 +384,10 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeNotVisibleOnFrontendOneConfigNone()
+    public function testHomeNotVisibleOnFrontendOneConfigExact()
     {
         Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_ANY);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_EXACT);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -421,7 +421,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
     public function testHomeVisibleInCMSOneConfigAny()
     {
         Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_ANY);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_EXACT);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -435,10 +435,10 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeNotVisibleInCMSBothConfigNone()
+    public function testHomeNotVisibleInCMSBothConfigExact()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_NONE);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_EXACT);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_EXACT);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -452,9 +452,9 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeNotVisibleInCMSOneConfigNone()
+    public function testHomeNotVisibleInCMSOneConfigExact()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_EXACT);
         Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_ANY);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
@@ -482,14 +482,14 @@ class FluentSiteTreeExtensionTest extends SapphireTest
     }
 
     /**
-     * @param string $cmsMode
-     * @param string $frontendMode
+     * @param string|bool $cmsMode
+     * @param string|bool $frontendMode
      * @param bool $isFrontend
      * @param int $expected
      * @throws ValidationException
      * @dataProvider localeFallbackProvider
      */
-    public function testPageVisibilityWithFallback(string $cmsMode, string $frontendMode, bool $isFrontend, int $expected)
+    public function testPageVisibilityWithFallback($cmsMode, $frontendMode, bool $isFrontend, int $expected)
     {
         Config::modify()
             ->set(DataObject::class, 'cms_localisation_required', $cmsMode)
@@ -524,28 +524,40 @@ class FluentSiteTreeExtensionTest extends SapphireTest
     {
         return [
             'Frontend / no inheritance' => [
-                FluentExtension::INHERITANCE_MODE_NONE,
-                FluentExtension::INHERITANCE_MODE_NONE,
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                FluentExtension::INHERITANCE_MODE_EXACT,
                 true,
                 0,
             ],
             'Frontend / fallback inheritance' => [
-                FluentExtension::INHERITANCE_MODE_NONE,
+                FluentExtension::INHERITANCE_MODE_EXACT,
                 FluentExtension::INHERITANCE_MODE_FALLBACK,
                 true,
                 1,
             ],
+            'Frontend / no inheritance (legacy)' => [
+                true,
+                true,
+                true,
+                0,
+            ],
             'CMS / no inheritance' => [
-                FluentExtension::INHERITANCE_MODE_NONE,
-                FluentExtension::INHERITANCE_MODE_NONE,
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                FluentExtension::INHERITANCE_MODE_EXACT,
                 false,
                 0,
             ],
             'CMS / fallback inheritance' => [
                 FluentExtension::INHERITANCE_MODE_FALLBACK,
-                FluentExtension::INHERITANCE_MODE_NONE,
+                FluentExtension::INHERITANCE_MODE_EXACT,
                 false,
                 1,
+            ],
+            'CMS / no inheritance (legacy)' => [
+                true,
+                true,
+                false,
+                0,
             ],
         ];
     }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -13,8 +13,10 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Versioned\Versioned;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
+use TractorCow\Fluent\Extension\FluentExtension;
 use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
 use TractorCow\Fluent\Extension\FluentVersionedExtension;
 use TractorCow\Fluent\Model\Domain;
@@ -91,11 +93,12 @@ class FluentSiteTreeExtensionTest extends SapphireTest
             $result = $page->Locales();
 
             $this->assertInstanceOf(ArrayList::class, $result);
-            $this->assertCount(5, $result);
+            $this->assertCount(6, $result);
             $this->assertListEquals([
                 ['Locale' => 'en_NZ'],
                 ['Locale' => 'de_DE'],
                 ['Locale' => 'en_US'],
+                ['Locale' => 'en_GB'],
                 ['Locale' => 'es_ES'],
                 ['Locale' => 'zh_CN'],
             ], $result);
@@ -161,7 +164,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
      * @param string $pageName
      * @param string $url
      */
-    public function testFluentURLs($domain, $locale, $prefixDisabled, $pageName, $url)
+    public function testFluentURLs(?string $domain, string $locale, bool $prefixDisabled, string $pageName, string $url)
     {
         FluentState::singleton()->withState(
             function (FluentState $newState) use ($domain, $locale, $prefixDisabled, $pageName, $url) {
@@ -201,7 +204,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
             $page = $this->objFromFixture(Page::class, 'staff');
             $page->config()
                 ->set('locale_published_status_message', true)
-                ->set('frontend_publish_required', true);
+                ->set('frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
 
             $fields = $page->getCMSFields();
 
@@ -224,7 +227,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
             $page = $this->objFromFixture(Page::class, 'home');
             $page->config()
                 ->set('locale_published_status_message', true)
-                ->set('frontend_publish_required', false);
+                ->set('frontend_publish_required', FluentExtension::INHERITANCE_MODE_ANY);
 
             $fields = $page->getCMSFields();
 
@@ -247,7 +250,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
             $page = $this->objFromFixture(Page::class, 'home');
             $page->config()
                 ->set('locale_published_status_message', true)
-                ->set('frontend_publish_required', false);
+                ->set('frontend_publish_required', FluentExtension::INHERITANCE_MODE_ANY);
             $page->write();
 
             $fields = $page->getCMSFields();
@@ -311,7 +314,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
      * @param string $expected
      * @dataProvider localePrefixUrlProvider
      */
-    public function testAddLocalePrefixToUrlSegment($localeCode, $fixture, $expected)
+    public function testAddLocalePrefixToUrlSegment(string $localeCode, string $fixture, string $expected)
     {
         FluentState::singleton()->withState(
             function (FluentState $newState) use ($localeCode, $fixture, $expected) {
@@ -319,7 +322,6 @@ class FluentSiteTreeExtensionTest extends SapphireTest
                     ->setLocale($localeCode)
                     ->setIsDomainMode(true);
 
-                /** @var FieldList $fields */
                 $fields = $this->objFromFixture(Page::class, $fixture)->getCMSFields();
 
                 /** @var SiteTreeURLSegmentField $segmentField */
@@ -331,10 +333,10 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         );
     }
 
-    public function testHomeVisibleOnFrontendBothConfigFalse()
+    public function testHomeVisibleOnFrontendBothConfigAny()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', false);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_ANY);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_ANY);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -348,10 +350,10 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeVisibleOnFrontendOneConfigFalse()
+    public function testHomeVisibleOnFrontendOneConfigAny()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', true);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_ANY);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -365,27 +367,10 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeNotVisibleOnFrontendBothConfigTrue()
+    public function testHomeNotVisibleOnFrontendBothConfigNone()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', true);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
-
-        FluentState::singleton()->withState(function (FluentState $newState) {
-            $newState
-                ->setLocale('de_DE')
-                ->setIsDomainMode(false)
-                ->setIsFrontend(true);
-
-            $page = Page::get()->filter('URLSegment', 'home')->first();
-
-            $this->assertNull($page);
-        });
-    }
-
-    public function testHomeNotVisibleOnFrontendOneConfigTrue()
-    {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', false);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -399,10 +384,27 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeVisibleInCMSBothConfigFalse()
+    public function testHomeNotVisibleOnFrontendOneConfigNone()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', false);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_ANY);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
+
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState
+                ->setLocale('de_DE')
+                ->setIsDomainMode(false)
+                ->setIsFrontend(true);
+
+            $page = Page::get()->filter('URLSegment', 'home')->first();
+
+            $this->assertNull($page);
+        });
+    }
+
+    public function testHomeVisibleInCMSBothConfigAny()
+    {
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_ANY);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_ANY);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -416,10 +418,10 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeVisibleInCMSOneConfigFalse()
+    public function testHomeVisibleInCMSOneConfigAny()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', false);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_ANY);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -433,10 +435,10 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeNotVisibleInCMSBothConfigTrue()
+    public function testHomeNotVisibleInCMSBothConfigNone()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', true);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_NONE);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -450,10 +452,10 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function testHomeNotVisibleInCMSOneConfigTrue()
+    public function testHomeNotVisibleInCMSOneConfigNone()
     {
-        Config::modify()->set(DataObject::class, 'cms_localisation_required', true);
-        Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
+        Config::modify()->set(DataObject::class, 'cms_localisation_required', FluentExtension::INHERITANCE_MODE_NONE);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', FluentExtension::INHERITANCE_MODE_ANY);
 
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState
@@ -476,6 +478,75 @@ class FluentSiteTreeExtensionTest extends SapphireTest
             'locale_with_domain'            => ['en_US', 'about', 'http://www.example.com/usa/'],
             'locale_without_domain'         => ['zh_CN', 'about', 'http://mocked/zh_CN/'],
             'locale_alone_on_domain_nested' => ['de_DE', 'staff', 'http://www.example.de/about-us/'],
+        ];
+    }
+
+    /**
+     * @param string $cmsMode
+     * @param string $frontendMode
+     * @param bool $isFrontend
+     * @param int $expected
+     * @throws ValidationException
+     * @dataProvider localeFallbackProvider
+     */
+    public function testPageVisibilityWithFallback(string $cmsMode, string $frontendMode, bool $isFrontend, int $expected)
+    {
+        Config::modify()
+            ->set(DataObject::class, 'cms_localisation_required', $cmsMode)
+            ->set(DataObject::class, 'frontend_publish_required', $frontendMode);
+
+        $pageId = FluentState::singleton()->withState(function (FluentState $state): int {
+            $state
+                ->setLocale('en_NZ')
+                ->setIsDomainMode(false);
+
+            // Intentionally avoiding fixtures as this is easier to maintain
+            $page = Page::create();
+            $page->Title = 'fallback-test';
+            $page->URLSegment = 'fallback-test';
+            $page->write();
+            $page->publishRecursive();
+
+            return $page->ID;
+        });
+
+        FluentState::singleton()->withState(function (FluentState $state) use ($isFrontend, $pageId, $expected) {
+            $state
+                ->setLocale('en_GB')
+                ->setIsDomainMode(false)
+                ->setIsFrontend($isFrontend);
+
+            $this->assertCount($expected, Page::get()->byIDs([$pageId]));
+        });
+    }
+
+    public function localeFallbackProvider(): array
+    {
+        return [
+            'Frontend / no inheritance' => [
+                FluentExtension::INHERITANCE_MODE_NONE,
+                FluentExtension::INHERITANCE_MODE_NONE,
+                true,
+                0,
+            ],
+            'Frontend / fallback inheritance' => [
+                FluentExtension::INHERITANCE_MODE_NONE,
+                FluentExtension::INHERITANCE_MODE_FALLBACK,
+                true,
+                1,
+            ],
+            'CMS / no inheritance' => [
+                FluentExtension::INHERITANCE_MODE_NONE,
+                FluentExtension::INHERITANCE_MODE_NONE,
+                false,
+                0,
+            ],
+            'CMS / fallback inheritance' => [
+                FluentExtension::INHERITANCE_MODE_FALLBACK,
+                FluentExtension::INHERITANCE_MODE_NONE,
+                false,
+                1,
+            ],
         ];
     }
 }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.yml
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.yml
@@ -7,6 +7,12 @@ TractorCow\Fluent\Model\Locale:
     Locale: en_US
     Title: 'English (US)'
     URLSegment: usa
+  uk:
+    Locale: en_GB
+    Title: 'English (GB)'
+    URLSegment: uk
+    Fallbacks:
+      - =>TractorCow\Fluent\Model\Locale.nz
   de:
     Locale: de_DE
     Title: German

--- a/tests/php/Model/Delete/Fixtures/LocalisedRecord.php
+++ b/tests/php/Model/Delete/Fixtures/LocalisedRecord.php
@@ -13,9 +13,9 @@ class LocalisedRecord extends DataObject implements TestOnly
 {
     private static $table_name = 'FluentDeleteTest_LocalisedRecord';
 
-    private static $frontend_publish_required = false;
+    private static $frontend_publish_required = FluentExtension::INHERITANCE_MODE_ANY;
 
-    private static $cms_localisation_required = false;
+    private static $cms_localisation_required = FluentExtension::INHERITANCE_MODE_ANY;
 
     private static $extensions = [
         FluentExtension::class,


### PR DESCRIPTION
# NEW: Locale fallback configuration enhancement

* Fallback option added to both `cms_localisation_required` and `frontend_publish_required`
* `cms_publish_required` removed as it's deprecated
* change is not backwards compatible but transition is possible (mapping below):

`false` -> `any`
`true` -> `exact`

Implementation of https://github.com/tractorcow-farm/silverstripe-fluent/issues/705