### PR TITLE
Feature: Allow timezones to be specified for each region

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -14,3 +14,8 @@ SilverStripe\ORM\DataObject:
 # Prevent duplicate siteconfigs when localised
 SilverStripe\SiteConfig\SiteConfig:
   frontend_publish_required: false
+
+# allow localised dates
+SilverStripe\ORM\FieldType\DBDatetime:
+  extensions:
+    fluentextension: TractorCow\Fluent\Extension\FluentDateTimeExtension

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -223,6 +223,32 @@ MySite\Model\MyModel:
 The result is that a DataObject that has *not* been Localised, will display on the frontend with content populated by
 it's Fallbacks (the same beheviour as what you see when viewing DataObjects from within the CMS).
 
+## Timezone
+
+Locales can also optionally have a Timezone assigned to each.
+
+Since all dates are stored in the timezone the server is located in (often NZ, or UTC)
+you will need to call another function to display a date/time in a local time.
+
+A default extension `FluentDateTimeExtension` allows you to use the `LocalTime` helper to render
+datetimes in the local time.
+
+E.g.
+
+```html
+<p>Hello, it is now {$Now.LocalTime.Nice}</p>
+```
+
+Or if you want to use local time in a summary field (where server time is UTC)
+
+```php
+ private static $summary_fields = [
+    'Title'                           => 'Title',
+    'Created'                         => 'Created (utc)',
+    'Created.getLocalTime.LocalValue' => 'Created (local)',
+];
+```
+
 ## SilverStripe Fluent and search
 
 ### SilverStripe Core search

--- a/src/Extension/FluentDateTimeExtension.php
+++ b/src/Extension/FluentDateTimeExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TractorCow\Fluent\Extension;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use TractorCow\Fluent\Model\LocalDateTime;
+use TractorCow\Fluent\Model\Locale;
+
+/**
+ * @property DBDatetime $owner
+ */
+class FluentDateTimeExtension extends Extension
+{
+    /**
+     * Convert datetime object to time in current timezone (timezone of current locale, not timezone of server)
+     *
+     * @return LocalDateTime
+     */
+    public function getLocalTime(): LocalDateTime
+    {
+        $locale = Locale::getCurrentLocale();
+        $timezone = $locale ? $locale->TimeZone : null;
+
+        // Note: Only specify timezone after assigning value, since most internal functions rely on value
+        // being in server timezone.
+        return LocalDateTime::create($this->owner->getName(), $this->owner->getOptions())
+            ->setValue($this->owner->getValue())
+            ->setTimezone($timezone);
+    }
+}

--- a/src/Extension/FluentDateTimeExtension.php
+++ b/src/Extension/FluentDateTimeExtension.php
@@ -20,10 +20,8 @@ class FluentDateTimeExtension extends Extension
     public function getLocalTime(): LocalDateTime
     {
         $locale = Locale::getCurrentLocale();
-        $timezone = $locale ? $locale->TimeZone : null;
+        $timezone = $locale ? $locale->Timezone : null;
 
-        // Note: Only specify timezone after assigning value, since most internal functions rely on value
-        // being in server timezone.
         return LocalDateTime::create($this->owner->getName(), $this->owner->getOptions())
             ->setValue($this->owner->getValue())
             ->setTimezone($timezone);

--- a/src/Model/LocalDateTime.php
+++ b/src/Model/LocalDateTime.php
@@ -2,7 +2,7 @@
 
 namespace TractorCow\Fluent\Model;
 
-use DateTimeImmutable;
+use DateTime;
 use DateTimeZone;
 use Exception;
 use IntlDateFormatter;
@@ -122,9 +122,10 @@ class LocalDateTime extends DBDatetime
 
         // Parse from local timezone
         $timezone = $this->getTimezone() ?: date_default_timezone_get();
-        $localTime = new DateTimeImmutable($value, new DateTimeZone($timezone));
+        $localTime = new DateTime($value, new DateTimeZone($timezone));
         $localTime->setTimezone(new DateTimeZone(date_default_timezone_get())); // Store in server timezone
-        $this->value = $localTime->format('Y-m-d H:i:s');
+        $serverValue = $localTime->format('Y-m-d H:i:s');
+        $this->value = $serverValue;
         return $this;
     }
 }

--- a/src/Model/LocalDateTime.php
+++ b/src/Model/LocalDateTime.php
@@ -49,13 +49,6 @@ class LocalDateTime extends DBDatetime
         return $this;
     }
 
-    /**
-     * @param null $locale
-     * @param null $pattern
-     * @param int $dateLength
-     * @param int $timeLength
-     * @return IntlDateFormatter
-     */
     public function getCustomFormatter(
         $locale = null,
         $pattern = null,

--- a/src/Model/LocalDateTime.php
+++ b/src/Model/LocalDateTime.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace TractorCow\Fluent\Model;
+
+use IntlDateFormatter;
+use InvalidArgumentException;
+use SilverStripe\ORM\FieldType\DBDatetime;
+
+/**
+ * Stores dates in the same timezone as DBDateTime, but will format them
+ * based on the timezone of another locale.
+ *
+ * Note: getValue() date will NOT be in the specified timezone. Only dates formatted via ->Format()
+ * or ->getLocalValue() will be converted as expected.
+ */
+class LocalDateTime extends DBDatetime
+{
+    protected $timezone = null;
+
+    public function __construct($name = null, $options = [], $timezone = null)
+    {
+        $this->timezone = $timezone;
+        parent::__construct($name, $options);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTimezone(): ?string
+    {
+        return $this->timezone;
+    }
+
+    /**
+     * Assign timezone
+     *
+     * @param string|null $timezone
+     * @return $this
+     */
+    public function setTimezone(?string $timezone): self
+    {
+        if ($timezone && !in_array($timezone, timezone_identifiers_list())) {
+            throw new InvalidArgumentException("Invalid timezone {$timezone}");
+        }
+        $this->timezone = $timezone;
+        return $this;
+    }
+
+    /**
+     * @param null $locale
+     * @param null $pattern
+     * @param int $dateLength
+     * @param int $timeLength
+     * @return IntlDateFormatter
+     */
+    public function getCustomFormatter(
+        $locale = null,
+        $pattern = null,
+        $dateLength = IntlDateFormatter::MEDIUM,
+        $timeLength = IntlDateFormatter::MEDIUM
+    ) {
+        $formatter = parent::getCustomFormatter($locale, $pattern, $dateLength, $timeLength);
+        $timezone = $this->getTimezone();
+        if ($timezone) {
+            $formatter->setTimeZone($timezone);
+        }
+        return $formatter;
+    }
+
+    /**
+     * Get ISO local value
+     *
+     * @return string
+     */
+    public function getLocalValue(): string
+    {
+        return $this->Format(self::ISO_DATETIME);
+    }
+}

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -2,6 +2,9 @@
 
 namespace TractorCow\Fluent\Model;
 
+use DateTime;
+use DateTimeZone;
+use Exception;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Config;
@@ -39,6 +42,7 @@ use TractorCow\Fluent\State\FluentState;
  * @property bool $IsGlobalDefault
  * @property int $DomainID
  * @property bool $UseDefaultCode
+ * @property string $TimeZone
  * @method HasManyList|FallbackLocale[] FallbackLocales()
  * @method ManyManyList|Locale[] Fallbacks()
  * @method Domain Domain() Raw SQL Domain (unfiltered by domain mode)
@@ -92,9 +96,16 @@ class Locale extends DataObject implements PermissionProvider
         'IsGlobalDefault' => 'Boolean',
         'UseDefaultCode'  => 'Boolean',
         'Sort'            => 'Int',
+        'TimeZone'        => 'Varchar(100)',
     ];
 
     private static $default_sort = '"Fluent_Locale"."Sort" ASC, "Fluent_Locale"."Locale" ASC';
+
+    public function populateDefaults()
+    {
+        parent::populateDefaults();
+        $this->TimeZone = date_default_timezone_get();
+    }
 
     /**
      * @config
@@ -284,6 +295,11 @@ class Locale extends DataObject implements PermissionProvider
                         __CLASS__ . '.USE_X_DEFAULT_DESCRIPTION',
                         'Use of this code indicates to search engines that this is a non-localised global landing page'
                     )),
+                DropdownField::create(
+                    'TimeZone',
+                    _t(__CLASS__ . '.TIMEZONE', 'Timezone'),
+                    $this->getTimeZones()
+                )->setEmptyString(_t(__CLASS__ . '.DEFAULT_NONE', '(none)')),
                 DropdownField::create(
                     'DomainID',
                     _t(__CLASS__ . '.DOMAIN', 'Domain'),
@@ -689,5 +705,39 @@ class Locale extends DataObject implements PermissionProvider
 
         // Access locale admin permission
         return LocaleAdmin::singleton()->canView($member);
+    }
+
+    /**
+     * Get list of timezones
+     *
+     * @return array
+     * @throws Exception
+     */
+    protected function getTimeZones()
+    {
+        static $timezones = null;
+        if ($timezones !== null) {
+            return $timezones;
+        }
+
+        $timezones = [];
+        $offsets = [];
+        $now = new DateTime('now', new DateTimeZone('UTC'));
+
+        foreach (DateTimeZone::listIdentifiers() as $timezone) {
+            $now->setTimezone(new DateTimeZone($timezone));
+            $offsets[] = $offset = $now->getOffset();
+
+            // Format offset
+            $hours = intval($offset / 3600);
+            $minutes = abs(intval($offset % 3600 / 60));
+            $name = str_replace(['/', '_', 'St'], [', ', ' ', 'St. '], $timezone);
+            $offsetTime = $offset ? sprintf('%+03d:%02d', $hours, $minutes) : '';
+            $timezones[$timezone] = "(GMT{$offsetTime}) {$name}";
+        }
+
+        array_multisort($offsets, $timezones);
+
+        return $timezones;
     }
 }

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -42,7 +42,7 @@ use TractorCow\Fluent\State\FluentState;
  * @property bool $IsGlobalDefault
  * @property int $DomainID
  * @property bool $UseDefaultCode
- * @property string $TimeZone
+ * @property string $Timezone
  * @method HasManyList|FallbackLocale[] FallbackLocales()
  * @method ManyManyList|Locale[] Fallbacks()
  * @method Domain Domain() Raw SQL Domain (unfiltered by domain mode)
@@ -96,7 +96,7 @@ class Locale extends DataObject implements PermissionProvider
         'IsGlobalDefault' => 'Boolean',
         'UseDefaultCode'  => 'Boolean',
         'Sort'            => 'Int',
-        'TimeZone'        => 'Varchar(100)',
+        'Timezone'        => 'Varchar(100)',
     ];
 
     private static $default_sort = '"Fluent_Locale"."Sort" ASC, "Fluent_Locale"."Locale" ASC';
@@ -104,7 +104,7 @@ class Locale extends DataObject implements PermissionProvider
     public function populateDefaults()
     {
         parent::populateDefaults();
-        $this->TimeZone = date_default_timezone_get();
+        $this->Timezone = date_default_timezone_get();
     }
 
     /**
@@ -296,9 +296,9 @@ class Locale extends DataObject implements PermissionProvider
                         'Use of this code indicates to search engines that this is a non-localised global landing page'
                     )),
                 DropdownField::create(
-                    'TimeZone',
+                    'Timezone',
                     _t(__CLASS__ . '.TIMEZONE', 'Timezone'),
-                    $this->getTimeZones()
+                    $this->getTimezones()
                 )->setEmptyString(_t(__CLASS__ . '.DEFAULT_NONE', '(none)')),
                 DropdownField::create(
                     'DomainID',
@@ -713,7 +713,7 @@ class Locale extends DataObject implements PermissionProvider
      * @return array
      * @throws Exception
      */
-    protected function getTimeZones()
+    protected function getTimezones()
     {
         static $timezones = null;
         if ($timezones !== null) {

--- a/tests/php/Model/LocalDateTimeTest.php
+++ b/tests/php/Model/LocalDateTimeTest.php
@@ -4,8 +4,10 @@ namespace TractorCow\Fluent\Tests\Model;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\ORM\FieldType\DBField;
 use TractorCow\Fluent\Extension\FluentDateTimeExtension;
 use TractorCow\Fluent\Model\Domain;
+use TractorCow\Fluent\Model\LocalDateTime;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
 
@@ -15,6 +17,7 @@ class LocalDateTimeTest extends SapphireTest
 
     public function setUp()
     {
+        // SapphireTest SetUp() sets timezone to UTC
         parent::setUp();
 
         // Clear cache
@@ -24,17 +27,41 @@ class LocalDateTimeTest extends SapphireTest
         DBDatetime::set_mock_now('2021-01-12 13:00:12');
     }
 
-//    public function testFromDBDatetime()
-//    {
-//        /** @var DBDatetime|FluentDateTimeExtension $date */
-//        $date = new DBDatetime('MyDate');
-//        $date->setValue('2021-02-33 11:59:59'); // UTC
-//
-//        // Convert to US timezone
-//        $localisedDate = $date->getLocalTime();
-//        $this->assertEquals('test', $localisedDate->getLocalValue());
-//
-//        // Internal time is non-modified (original UTC timezone)
-//        $this->assertEquals('2021-02-33 11:59:59', $localisedDate->getValue());
-//    }
+    public function testFromDBDatetime()
+    {
+        /** @var DBDatetime|FluentDateTimeExtension $date */
+        $date = DBField::create_field('Datetime', '2021-02-18 11:59:59'); // UTC
+
+        // Convert to US timezone
+        $localisedDate = $date->getLocalTime();
+        $this->assertEquals('2021-02-18 06:59:59', $localisedDate->getLocalValue()); // US time, 5 hours before UTC
+
+        // Internal time is non-modified (original UTC timezone)
+        $this->assertEquals('2021-02-18 11:59:59', $localisedDate->getValue());
+
+        // Change to NZ timezone
+        $localisedDate->setTimezone('Pacific/Auckland');
+        $this->assertEquals('2021-02-19 00:59:59', $localisedDate->getLocalValue()); // NZ is 13 hours after UTC
+    }
+
+    public function testSetValue()
+    {
+        $date = new LocalDateTime();
+        $date->setLocalValue('2021-02-19 00:59:59', 'Pacific/Auckland');
+
+        // Internal time is non-modified (original UTC timezone)
+        $this->assertEquals('Pacific/Auckland', $date->getTimezone());
+        $this->assertEquals('2021-02-18 11:59:59', $date->getValue()); // Converted back to UTC for storage
+        $this->assertEquals('2021-02-19 00:59:59', $date->getLocalValue()); // NZ is 13 hours after UTC
+
+        // Convert from NZ to US time
+        $date->setTimezone('America/New_York');
+        $this->assertEquals('2021-02-18 06:59:59', $date->getLocalValue()); // 5 hours before UTC
+
+        // Test normal setValue (ignores timezone, sets as per server timezone)
+        // Set value 1 hour into the future
+        $date->setValue('2021-02-18 12:59:59');
+        $this->assertEquals('2021-02-18 12:59:59', $date->getValue());
+        $this->assertEquals('2021-02-18 07:59:59', $date->getLocalValue()); // 5 hours before UTC
+    }
 }

--- a/tests/php/Model/LocalDateTimeTest.php
+++ b/tests/php/Model/LocalDateTimeTest.php
@@ -64,4 +64,43 @@ class LocalDateTimeTest extends SapphireTest
         $this->assertEquals('2021-02-18 12:59:59', $date->getValue());
         $this->assertEquals('2021-02-18 07:59:59', $date->getLocalValue()); // 5 hours before UTC
     }
+
+
+    /**
+     * Test all DB locales
+     *
+     * @dataProvider provideTestSwitchLocales
+     * @param $locales
+     */
+    public function testSwitchLocales($locale, $expectedTime)
+    {
+        /** @var DBDatetime|FluentDateTimeExtension $date */
+        $date = DBField::create_field('Datetime', '2021-01-12 13:00:12'); // UTC
+        FluentState::singleton()->withState(function (FluentState $state) use ($locale, $expectedTime, $date) {
+            $state->setLocale($locale);
+            $this->assertEquals($expectedTime, $date->getLocalTime()->getLocalValue());
+        });
+    }
+
+    public function provideTestSwitchLocales()
+    {
+        return [
+            [
+                'locale'    => 'en_NZ',
+                'localTIme' => '2021-01-13 02:00:12',
+            ],
+            [
+                'locale'    => 'en_AU',
+                'localTime' => '2021-01-12 23:00:12',
+            ],
+            [
+                'locale'    => 'es_ES',
+                'localTime' => '2021-01-12 14:00:12',
+            ],
+            [
+                'locale'    => 'es_US',
+                'localTime' => '2021-01-12 08:00:12',
+            ],
+        ];
+    }
 }

--- a/tests/php/Model/LocalDateTimeTest.php
+++ b/tests/php/Model/LocalDateTimeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Model;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use TractorCow\Fluent\Extension\FluentDateTimeExtension;
+use TractorCow\Fluent\Model\Domain;
+use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\State\FluentState;
+
+class LocalDateTimeTest extends SapphireTest
+{
+    protected static $fixture_file = 'LocaleTest.yml';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // Clear cache
+        Locale::clearCached();
+        Domain::clearCached();
+        FluentState::singleton()->setLocale('es_US');
+        DBDatetime::set_mock_now('2021-01-12 13:00:12');
+    }
+
+//    public function testFromDBDatetime()
+//    {
+//        /** @var DBDatetime|FluentDateTimeExtension $date */
+//        $date = new DBDatetime('MyDate');
+//        $date->setValue('2021-02-33 11:59:59'); // UTC
+//
+//        // Convert to US timezone
+//        $localisedDate = $date->getLocalTime();
+//        $this->assertEquals('test', $localisedDate->getLocalValue());
+//
+//        // Internal time is non-modified (original UTC timezone)
+//        $this->assertEquals('2021-02-33 11:59:59', $localisedDate->getValue());
+//    }
+}

--- a/tests/php/Model/LocaleTest.yml
+++ b/tests/php/Model/LocaleTest.yml
@@ -2,16 +2,20 @@ TractorCow\Fluent\Model\Locale:
   en_NZ:
     Locale: en_NZ
     URLSegment: nz
+    Timezone: Pacific/Auckland
   en_AU:
     Locale: en_AU
     URLSegment: au
     IsGlobalDefault: 1
+    Timezone: Australia/Brisbane
   es_ES:
     Locale: es_ES
     URLSegment: es
+    Timezone: Europe/Madrid
   es_US:
     Locale: es_US
     URLSegment: es-usa
+    Timezone: America/New_York
 
 TractorCow\Fluent\Model\Domain:
   kiwi:


### PR DESCRIPTION
Helpful for when a date needs to be shown in different timezones in any region.

Since DBDatetime doesn't internally support a timezone, we rely on storage in the server timezone, and only convert on rendering output. (otherwise, internal functions like strtotime are wrong).