### PR TITLE
BUG: Missing version tables related indexes.

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -67,6 +67,15 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
                 'Version',
             ],
         ],
+        // Needed to speedup version table joins which are used in Version related operations
+        // such as isPublishedInLocale
+        'Fluent_Version' => [
+            'type' => 'index',
+            'columns' => [
+                'RecordID',
+                'Version',
+            ],
+        ],
     ];
 
     /**


### PR DESCRIPTION
# BUG: Missing version tables related indexes

I noticed that some JOIN operation on version tables can be slow on large DB size type projects.

There are at least two cases where this is notable:

* [Version joins](https://github.com/tractorcow-farm/silverstripe-fluent/blob/master/src/Extension/FluentVersionedExtension.php#L425)
* Cleanup / lookups of versions where join through multiple tables is needed

This change adds the needed indexes.

## Questions

* Should this be a configuration API variable instead to allow more control over this?