### PR TITLE
Consolidate some redundant logic in code

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -666,7 +666,6 @@ class FluentExtension extends DataExtension
                 continue;
             }
 
-            $locale = $recordLocale->getLocaleObject();
             if ($recordLocale->getLocale() === $currentLocale) {
                 // We only need to handle other locale instances, current locale doesn't need updates
                 continue;


### PR DESCRIPTION
@mfendeksilverstripe these are the suggested changes I had in mind to follow up to #717

I switched out some of the logic in your loopy for checks / queries that were already handled in RecordLocale.

getLocaleInstances was also simplified slightly by re-using this logic.

I have another PR coming up (will take some time to progress) that adjusts the internal storage for localisations to use the localeID