### PR TITLE
[WIP] Localise records by locale ID not by code

### DIFF
--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -24,6 +24,7 @@ use SilverStripe\ORM\ManyManyList;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
+use SilverStripe\Versioned\Versioned;
 use Symbiote\GridFieldExtensions\GridFieldAddNewInlineButton;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
@@ -95,6 +96,27 @@ class Locale extends DataObject implements PermissionProvider
     ];
 
     private static $default_sort = '"Fluent_Locale"."Sort" ASC, "Fluent_Locale"."Locale" ASC';
+
+    /**
+     * Currently, locale codes must be unique across locale objects
+     *
+     * @var array[]
+     */
+    private static $indexes = [
+        'Locale_Locale' => [
+            'type'    => 'unique',
+            'columns' => ['Locale'],
+        ],
+    ];
+
+    /**
+     * Version locales to track changes to localisations over time
+     *
+     * @var string[]
+     */
+    private static $extensions = [
+        'versioned' => Versioned::class . '.versioned',
+    ];
 
     /**
      * @config


### PR DESCRIPTION
Still in progress, needs to be tested, and I need to come up with a migration plan. Ideally upgrading to 6.0 should just be a dev/build, and missing records would be fixed.

The advantage of this is that now, if you have localised your site in one locale, you can actually tweak or change the locale code without having to re-enter all of your content. E.g. if your locale changes from en_NZ to en_AU, your localisations for en_NZ don't disappear, but just appear as en_AU.

Theoretically, in the future we could also allow multiple locales to share the same locale code (since we would be keying by locale ID).

However, I'm not 100% sure we should even merge this change. The downside to this is that localisations are now tied to locale records.

Also, it's possible that you may not always want to tie a localisation row to a locale record; The localisations now follow that record, but maybe it would make switching localisations to ANOTHER locale object harder?