### PR TITLE
feat(site tree extension): add option to disable locale prepend to link

### DIFF
--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -95,6 +95,10 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
      */
     public function updateRelativeLink(&$base, &$action)
     {
+
+        if ($this->owner->hasMethod('disablePrependLocaleURLSegmentToLink') && $this->owner->disablePrependLocaleURLSegmentToLink()) {
+            return;
+        }
         // Don't inject locale to subpages
         if ($this->owner->ParentID && SiteTree::config()->get('nested_urls')) {
             return;


### PR DESCRIPTION
Allow for usage with headless front end frameworks where you might not always want the locale url segment prepended to the link