### PR TITLE
BUG: Fix for FluentAdminTraitTest.

### DIFF
--- a/tests/php/Extension/FluentAdminTraitTest.yml
+++ b/tests/php/Extension/FluentAdminTraitTest.yml
@@ -1,0 +1,13 @@
+# Three locales - English and German will have translated records and Spanish records will be created
+# by the unit tests
+TractorCow\Fluent\Model\Locale:
+  default:
+    Title: US English
+    Locale: en_US
+    IsGlobalDefault: true
+  german:
+    Title: German
+    Locale: de_DE
+  spanish:
+    Title: Spanish
+    Locale: es_ES

--- a/tests/php/Extension/FluentExtensionTest/LocalisedParent.php
+++ b/tests/php/Extension/FluentExtensionTest/LocalisedParent.php
@@ -7,6 +7,8 @@ use SilverStripe\ORM\DataObject;
 use TractorCow\Fluent\Extension\FluentExtension;
 
 /**
+ * @property string $Title
+ * @property string $Description
  * @mixin FluentExtension
  */
 class LocalisedParent extends DataObject implements TestOnly


### PR DESCRIPTION
# BUG: Fix for FluentAdminTraitTest

This test shows a failure in one of the past CI runs on `master`. I reviewed the test and it seems some of the setup was incorrect. The test is passing on my local and I believe my change is updating the test to assert what was intended. I'm unable to fully validate this fix until https://github.com/tractorcow-farm/silverstripe-fluent/issues/734 is resolved though.

![Screen Shot 2021-10-21 at 9 53 44 AM](https://user-images.githubusercontent.com/26395487/138170639-df835b16-4b97-4d1a-8c3f-b6b5d7be05b1.png)


