### PR TITLE
BUG: Localisation manager / Locale link fix for AJAX requests.

### DIFF
--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -552,13 +552,15 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
         }
 
         // This is to get URL only, getVars are not part of the URL
-        $url = $request->getURL();
-        // Pass getVars separately so we can process them later
-        $params = $request->getVars();
+        $url = $this->owner->CMSEditLink();
 
         if (!$url) {
             return;
         }
+
+        // Pass getVars separately so we can process them later
+        $params = $request->getVars();
+        $url = Director::makeRelative($url);
 
         $summaryColumns['Title'] = [
             'title' => 'Title',


### PR DESCRIPTION
# BUG: Localisation manager / Locale link fix for AJAX requests.

* Now using CMS edit link instead of current URL as the latter can change in some situations like AJAX requests

Fix for https://github.com/tractorcow-farm/silverstripe-fluent/issues/740