### PR TITLE
NEW: Copy to locale enhancements.

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -34,6 +34,7 @@ use TractorCow\Fluent\Forms\GroupActionMenu;
 use TractorCow\Fluent\Model\Delete\UsesDeletePolicy;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\Model\RecordLocale;
+use TractorCow\Fluent\Service\CopyToLocaleService;
 use TractorCow\Fluent\State\FluentState;
 
 /**
@@ -1373,6 +1374,19 @@ class FluentExtension extends DataExtension
         } finally {
             $this->localisedCopyActive = $active;
         }
+    }
+
+    /**
+     * Copy data object content from current locale to the target locale
+     *
+     * @param string $toLocale
+     * @throws ValidationException
+     */
+    public function copyToLocale(string $toLocale): void
+    {
+        $owner = $this->owner;
+        $fromLocale = FluentState::singleton()->getLocale();
+        CopyToLocaleService::singleton()->copyToLocale($owner->ClassName, $owner->ID, $fromLocale, $toLocale);
     }
 
     /**

--- a/src/Service/CopyToLocaleService.php
+++ b/src/Service/CopyToLocaleService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace TractorCow\Fluent\Service;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Versioned\Versioned;
+use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\State\FluentState;
+
+/**
+ * Copy content between locales
+ */
+class CopyToLocaleService
+{
+    use Injectable;
+
+    /**
+     * Copy data object content between locales
+     *
+     * @param string $class
+     * @param int $id
+     * @param string $fromLocale
+     * @param string $toLocale
+     * @throws ValidationException
+     */
+    public function copyToLocale(string $class, int $id, string $fromLocale, string $toLocale): void
+    {
+        // Load record in base locale
+        FluentState::singleton()->withState(
+            function (FluentState $sourceState) use ($class, $id, $fromLocale, $toLocale) {
+                $sourceLocale = Locale::getByLocale($fromLocale);
+
+                if (!$sourceLocale) {
+                    return;
+                }
+
+                $sourceState->setLocale($sourceLocale->getLocale());
+
+                // Load record in source locale
+                $record = DataObject::get($class)->byID($id);
+
+                if (!$record) {
+                    return;
+                }
+
+                // Save record to other locale
+                $sourceState->withState(function (FluentState $destinationState) use ($record, $fromLocale, $toLocale) {
+                    $targetLocale = Locale::getByLocale($toLocale);
+
+                    if (!$targetLocale) {
+                        return;
+                    }
+
+                    $destinationState->setLocale($targetLocale->getLocale());
+
+                    $record->invokeWithExtensions('onBeforeCopyLocale', $fromLocale, $toLocale);
+
+                    // Write
+                    /** @var DataObject|Versioned $record */
+                    if ($record->hasExtension(Versioned::class)) {
+                        $record->writeToStage(Versioned::DRAFT);
+                    } else {
+                        $record->forceChange();
+                        $record->write();
+                    }
+
+                    $record->invokeWithExtensions('onAfterCopyLocale', $fromLocale, $toLocale);
+                });
+            }
+        );
+    }
+}


### PR DESCRIPTION
# NEW: Copy to locale enhancements

It turns out that copy to locale feature is really good! This enhancement contains no functional changes but it opens this feature to be used via public API. This is useful in situations where GridField UI is not appropriate solution like migrations, custom UI or similar.

* generic API is available via a service
* `FluentExtension` provides a simplified API intended for the most common case