### PR TITLE
NEW: More granular permissions for GridField actions.

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -1303,16 +1303,12 @@ class FluentExtension extends DataExtension
 
     /**
      * Add copy actions to each locale
+     * Note that permissions for these actions are resolved within the GridField components themselves
      *
      * @param GridFieldConfig $config
      */
     public function updateLocalisationTabConfig(GridFieldConfig $config)
     {
-        // Add cross-locale actions (if allowed)
-        if (!Permission::check(Locale::CMS_ACCESS_MULTI_LOCALE)) {
-            return;
-        }
-
         // Add locale copy actions
         $config->addComponents([
             new GroupActionMenu(

--- a/src/Forms/BaseAction.php
+++ b/src/Forms/BaseAction.php
@@ -8,6 +8,7 @@ use SilverStripe\Forms\GridField\GridField_ActionMenuItem;
 use SilverStripe\Forms\GridField\GridField_ActionProvider;
 use SilverStripe\Forms\GridField\GridField_FormAction;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Permission;
 use TractorCow\Fluent\Model\Locale;
 
 /**
@@ -70,7 +71,6 @@ abstract class BaseAction implements GridField_ActionProvider, GridField_ActionM
         return null;
     }
 
-
     /**
      * Given a gridfield, and either an ID or record, return a list with
      * both the record  being localised, and the locale object
@@ -93,5 +93,24 @@ abstract class BaseAction implements GridField_ActionProvider, GridField_ActionM
         // E.g. list of blog posts in one locale
         $locale = Locale::getCurrentLocale();
         return [$rowRecord, $locale];
+    }
+
+    /**
+     * Validate locale permission for specific locale
+     *
+     * @param string $locale
+     * @return bool
+     */
+    protected function validateLocalePermissions(string $locale): bool
+    {
+        if (Permission::check(Locale::CMS_ACCESS_MULTI_LOCALE)) {
+            // The user has permission to access all locales, no further checks are needed
+            return true;
+        }
+
+        $localeObject = Locale::getByLocale($locale);
+
+        // Validate permission of the target locale
+        return Permission::check($localeObject->getLocaleEditPermission());
     }
 }

--- a/src/Forms/GroupActionMenu.php
+++ b/src/Forms/GroupActionMenu.php
@@ -56,6 +56,14 @@ class GroupActionMenu extends GridField_ActionMenu
             if ($group !== $this->group) {
                 continue;
             }
+
+            $extraData = $item->getExtraData($gridField, $record, $columnName);
+
+            if (array_key_exists('disabled', $extraData) && $extraData['disabled']) {
+                // Skip disabled components (likely disabled because of permissions)
+                continue;
+            }
+
             $schema[] = [
                 'type'  => $item instanceof GridField_ActionMenuLink ? 'link' : 'submit',
                 'title' => $item->getTitle($gridField, $record, $columnName),
@@ -63,7 +71,7 @@ class GroupActionMenu extends GridField_ActionMenu
                     ? $item->getUrl($gridField, $record, $columnName)
                     : null,
                 'group' => $this->group,
-                'data'  => $item->getExtraData($gridField, $record, $columnName),
+                'data'  => $extraData,
             ];
         }
 


### PR DESCRIPTION
# NEW: More granular permissions for GridField actions

* copy to locale action now respects individual locale permissions
* publish action now respects individual locale permissions
* un-publish action now respects individual locale permissions

## UI impact

User with access to only a single locale.

![Screen Shot 2022-02-08 at 2 33 48 PM](https://user-images.githubusercontent.com/26395487/152904806-5a84d1ce-14b3-4fc1-9bd9-ff1a8edc87d1.png)

No change for user with access to all locales.

![Screen Shot 2022-02-08 at 2 49 23 PM](https://user-images.githubusercontent.com/26395487/152904736-dad107de-e7df-467e-9f18-448a62a2fc19.png)

## Tests

Tests passing on my local.

![Screen Shot 2022-02-08 at 2 43 25 PM](https://user-images.githubusercontent.com/26395487/152904890-9f57c6cb-427e-4771-9cf5-a79e98183fba.png)

