### PR TITLE
Bump CI version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.9
+    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.13


### PR DESCRIPTION
Most recent version includes a security enhancement to treat input strings as env variables rather than string substitution

After merging this should be merged up to the `4` branch