### PR TITLE
BUG Fix copyFluent action writing all locales including original

### DIFF
--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -277,7 +277,14 @@ trait FluentAdminTrait
         $record = $form->getRecord();
         $record->flushCache(true);
 
-        $this->inEveryLocale(function () use ($record) {
+        $originalLocale = Locale::getCurrentLocale();
+
+        $this->inEveryLocale(function () use ($record, $originalLocale) {
+            // Skip original locale
+            if ($locale->ID == $originalLocale->ID) {
+                return;
+            }
+            
             if ($record->hasExtension(Versioned::class)) {
                 $record->writeToStage(Versioned::DRAFT);
             } else {

--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -279,7 +279,7 @@ trait FluentAdminTrait
 
         $originalLocale = Locale::getCurrentLocale();
 
-        $this->inEveryLocale(function () use ($record, $originalLocale) {
+        $this->inEveryLocale(function (Locale $locale) use ($record, $originalLocale) {
             // Skip original locale
             if ($locale->ID == $originalLocale->ID) {
                 return;


### PR DESCRIPTION
Copy 'Locale' to other locales now writes to every locale. I think this is unnecessary and in some cases causes bugs.

Now skipping the original locale.