### PR TITLE
NEW: Locale performance / extensibility enhancements.

### DIFF
--- a/src/Extension/FluentFilteredExtension.php
+++ b/src/Extension/FluentFilteredExtension.php
@@ -39,7 +39,7 @@ class FluentFilteredExtension extends DataExtension
 
     public function updateCMSFields(FieldList $fields)
     {
-        $locales = Locale::get();
+        $locales = Locale::getCached();
 
         // If there are no Locales, then we're not adding any fields.
         if ($locales->count() === 0) {

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -122,11 +122,6 @@ class Locale extends DataObject implements PermissionProvider
     protected $chain = null;
 
     /**
-     * @var Locale[]
-     */
-    protected static $locales_by_title;
-
-    /**
      * Get internal title for this locale
      *
      * @return string
@@ -366,11 +361,12 @@ class Locale extends DataObject implements PermissionProvider
     /**
      * Get current locale object
      *
-     * @return Locale
+     * @return Locale|null
      */
-    public static function getCurrentLocale()
+    public static function getCurrentLocale(): ?Locale
     {
         $locale = FluentState::singleton()->getLocale();
+
         return static::getByLocale($locale);
     }
 
@@ -378,9 +374,9 @@ class Locale extends DataObject implements PermissionProvider
      * Get object by locale code.
      *
      * @param string|Locale $locale
-     * @return Locale
+     * @return Locale|null
      */
-    public static function getByLocale($locale)
+    public static function getByLocale($locale): ?Locale
     {
         if (!$locale) {
             return null;
@@ -390,15 +386,8 @@ class Locale extends DataObject implements PermissionProvider
             return $locale;
         }
 
-        if (!static::$locales_by_title) {
-            static::$locales_by_title = [];
-            foreach (Locale::getCached() as $localeObj) {
-                static::$locales_by_title[$localeObj->Locale] = $localeObj;
-            }
-        }
-
         // Get filtered locale
-        return isset(static::$locales_by_title[$locale]) ? static::$locales_by_title[$locale] : null;
+        return Locale::getCached()->find('Locale', $locale);
     }
 
     /**


### PR DESCRIPTION
# NEW: Locale performance / extensibility enhancements.

* **Performance**: All instances of `Locale::get()` replaced with `Locale::getCached()` to take advantage of in-memory cache
* **Extensibility**: [Cachable model injection point](https://github.com/tractorcow-farm/silverstripe-fluent/blob/master/src/Model/CachableModel.php#L25) now covers all locale calls which allows consistency in case this is used to customise cached locales data
* **Cleanup**: In-memory cache for locale code lookup removed as this was already operating on top of another memory cache (cached models), the performance gain is negligible and is not worth keeping the additional complexity, also this in-memory cache was not flushed between unit tests and could interfere with [Cachable model injection point](https://github.com/tractorcow-farm/silverstripe-fluent/blob/master/src/Model/CachableModel.php#L25)

Tests passing on my local.

![Screen Shot 2022-03-10 at 12 32 25 PM](https://user-images.githubusercontent.com/26395487/157557615-a1abc169-ae8f-40f5-98f8-336516a6d46a.png)