### PR TITLE
fix: issue with "all cms sections" permission erroneously handling fluent permissions

### DIFF
--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -54,7 +54,7 @@ class Locale extends DataObject implements PermissionProvider
     /**
      * Code for accessing cross-locale actions
      */
-    const CMS_ACCESS_MULTI_LOCALE = 'CMS_ACCESS_Fluent_Actions_MultiLocale';
+    const CMS_ACCESS_MULTI_LOCALE = 'Fluent_Actions_MultiLocale';
 
     /**
      * Prefix for per-locale permission code.
@@ -62,7 +62,7 @@ class Locale extends DataObject implements PermissionProvider
      * Note that this is not a permission code in itself, and must always be
      * joined with a locale.
      */
-    const CMS_ACCESS_FLUENT_LOCALE = "CMS_ACCESS_Fluent_Locale_";
+    const CMS_ACCESS_FLUENT_LOCALE = 'Fluent_Locale_';
 
     private static $table_name = 'Fluent_Locale';
 
@@ -136,6 +136,22 @@ class Locale extends DataObject implements PermissionProvider
      * @var Locale[]
      */
     protected static $locales_by_title;
+
+    public function requireDefaultRecords()
+    {
+        parent::requireDefaultRecords();
+
+        // Migrate legacy permission codes to new codes
+        $permissions = Permission::get()->filter('Code:StartsWith', 'CMS_ACCESS_Fluent_');
+        $count = $permissions->count();
+        if ($count) {
+            DB::alteration_message("Migrating ${$count} old fluent permissions", 'changed');
+        }
+        foreach ($permissions as $permission) {
+            $permission->Code = str_replace('CMS_ACCESS_Fluent_', 'Fluent_', $permission->Code);
+            $permission->write();
+        }
+    }
 
     /**
      * Get internal title for this locale


### PR DESCRIPTION
I attempted to reproduce https://github.com/tractorcow-farm/silverstripe-fluent/issues/751 but I had a few problems getting the same symptoms.

In any case, I fixed the permissions code so that the locale-permissions no longer get set to readonly if you check "all cms permissions".