### PR TITLE
MNT Use v0.1 of ci workflow (4 branch)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,4 +6,6 @@ on:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.9
+    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@v0.1
+    with:
+      run_phplinting: false


### PR DESCRIPTION
Use v0.1 version of the ci.yml file, which is a special version of the workflow that is re-released whenever a new tag matching 0.1.x is created.  Effectively simulates ^ caret support for github workflows which do not support carets.
