### PR TITLE
FIX Don't try to preview unlocalised objects

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -1137,6 +1137,22 @@ class FluentExtension extends DataExtension
     }
 
     /**
+     * Update preview link to null if the object isn't in the current locale
+     * and we can't fallback cleanly.
+     *
+     * @param ?string $link
+     */
+    public function updatePreviewLink(&$link): void
+    {
+        $owner = $this->owner;
+        $info = $owner->LocaleInformation(FluentState::singleton()->getLocale());
+
+        if (!$info->getSourceLocale()) {
+            $link = null;
+        }
+    }
+
+    /**
      * Require that this record is saved in the given locale for it to be visible
      *
      * @return string

--- a/src/Middleware/InitStateMiddleware.php
+++ b/src/Middleware/InitStateMiddleware.php
@@ -70,11 +70,6 @@ class InitStateMiddleware implements HTTPMiddleware
             }
         }
 
-        // If using the CMS preview, do not treat the site as frontend
-        if ($request->getVar('CMSPreview')) {
-            return false;
-        }
-
         return true;
     }
 

--- a/tests/php/Middleware/InitStateMiddlewareTest.php
+++ b/tests/php/Middleware/InitStateMiddlewareTest.php
@@ -35,7 +35,8 @@ class InitStateMiddlewareTest extends SapphireTest
             ['/', [], true],
             ['foo', [], true],
             ['my-blog/my-post', [], true],
-            ['my-blog/my-post', ['CMSPreview' => 1], false],
+            // CMS preview is front-end, and if there's no localised copy the PreviewLink will be null
+            ['my-blog/my-post', ['CMSPreview' => 1], true],
         ];
     }
 }


### PR DESCRIPTION
I don't think there's ever a scenario where you'd _want_ to consider previews as not frontend so I don't think this is a breaking change.
I'm on the fence about whether `updatePreviewLink()` belongs here or in `FluentExtension` directly. _Probably_ it belongs on `FluentExtension` so it can affect anything else which have a preview (e.g. elemental blocks which aren't inline-editable) - but I'll leave it like this for now (it is still an improvement and solves the specific exact scenario mentioned in the issue) until someone opines.

## Parent issue
- https://github.com/tractorcow-farm/silverstripe-fluent/issues/775