### PR TITLE
API Deprecate API removed in fluent 5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: Module CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@v0.1
-    with:
-      run_phplinting: false
+    name: CI
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/_config.php
+++ b/_config.php
@@ -1,5 +1,0 @@
-<?php
-
-use SilverStripe\Dev\Deprecation;
-
-Deprecation::notification_version('4.0.0', 'tractorcow/silverstripe-fluent');

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "silverstripe/vendor-plugin": "^1",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4",
         "silverstripe/cms": "^4",
         "symbiote/silverstripe-gridfieldextensions": "^3.1"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,6 +2,9 @@
 <ruleset name="SilverStripe">
     <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
 
+	<file>src</file>
+	<file>tests</file>
+
     <!-- base rules are PSR-2 -->
     <rule ref="PSR2" >
         <!-- Current exclusions -->

--- a/src/Extension/FluentBadgeExtension.php
+++ b/src/Extension/FluentBadgeExtension.php
@@ -3,6 +3,7 @@
 namespace TractorCow\Fluent\Extension;
 
 use SilverStripe\Core\Extension;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
@@ -11,6 +12,24 @@ use TractorCow\Fluent\State\FluentState;
 
 class FluentBadgeExtension extends Extension
 {
+
+    public function __construct()
+    {
+        $deprecation = function () {
+            Deprecation::notice(
+                '4.13.0',
+                'Will be replaced with using TractorCow\Fluent\Extension\Traits\FluentBadgeTrait on an extension instead',
+                Deprecation::SCOPE_CLASS
+            );
+        };
+        if (method_exists(Deprecation::class, 'withNoReplacement')) {
+            Deprecation::withNoReplacement($deprecation);
+        } else {
+            $deprecation();
+        }
+
+        parent::__construct();
+    }
     /**
      * Push a badge to indicate the language that owns the current item
      *

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extension;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\ArrayList;
@@ -826,10 +827,10 @@ class FluentExtension extends DataExtension
         $locale = $localeObj->getLocale();
 
         // Check linking mode
-        $linkingMode = $this->getLinkingMode($locale);
+        $linkingMode = $this->getLinkingModeValue($locale);
 
         // Check link
-        $link = $this->LocaleLink($locale);
+        $link = $this->getLocaleLinkValue($locale);
 
         // Store basic locale information
         return ArrayData::create([
@@ -852,6 +853,12 @@ class FluentExtension extends DataExtension
      * @return string
      */
     public function getLinkingMode($locale)
+    {
+        Deprecation::notice('4.13.0', 'Use LocaleInformation() instead');
+        return $this->getLinkingModeValue($locale);
+    }
+
+    private function getLinkingModeValue($locale)
     {
         if ($this->owner->hasMethod('canViewInLocale') && !$this->owner->canViewInLocale($locale)) {
             return 'invalid';
@@ -884,6 +891,12 @@ class FluentExtension extends DataExtension
      * @return string
      */
     public function LocaleLink($locale)
+    {
+        Deprecation::notice('4.13.0', 'Use LocaleInformation() instead');
+        return $this->getLocaleLinkValue($locale);
+    }
+
+    private function getLocaleLinkValue($locale)
     {
         // Skip dataobjects that do not have the Link method
         if (!$this->owner->hasMethod('Link')) {


### PR DESCRIPTION
Also updated to use the new gha-ci instead of the old experimental one

Because we're using `Deprecation::withNoReplacement()` this cannot be used with framework < 4.13

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/666