### PR TITLE
 API Deprecate API removed in fluent 5 (suggested)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: Module CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@v0.1
-    with:
-      run_phplinting: false
+    name: CI
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/_config.php
+++ b/_config.php
@@ -1,5 +1,0 @@
-<?php
-
-use SilverStripe\Dev\Deprecation;
-
-Deprecation::notification_version('4.0.0', 'tractorcow/silverstripe-fluent');

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "silverstripe/vendor-plugin": "^1",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.13",
         "silverstripe/cms": "^4",
         "symbiote/silverstripe-gridfieldextensions": "^3.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "silverstripe/vendor-plugin": "^1",
-        "silverstripe/framework": "^4.13",
+        "silverstripe/framework": "^4",
         "silverstripe/cms": "^4",
         "symbiote/silverstripe-gridfieldextensions": "^3.1"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,6 +2,8 @@
 <ruleset name="SilverStripe">
     <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
 
+    <file>./src</file>
+
     <!-- base rules are PSR-2 -->
     <rule ref="PSR2" >
         <!-- Current exclusions -->

--- a/src/Extension/FluentBadgeExtension.php
+++ b/src/Extension/FluentBadgeExtension.php
@@ -15,16 +15,22 @@ class FluentBadgeExtension extends Extension
 
     public function __construct()
     {
-        Deprecation::withNoReplacement(function () {
+        $deprecation = function () {
             Deprecation::notice(
                 '4.13.0',
                 'Will be replaced with using TractorCow\Fluent\Extension\Traits\FluentBadgeTrait on an extension instead',
                 Deprecation::SCOPE_CLASS
             );
-        });
+        };
+        if (method_exists(Deprecation::class, 'withNoReplacement')) {
+            Deprecation::withNoReplacement($deprecation);
+        } else {
+            $deprecation();
+        }
 
         parent::__construct();
     }
+
     /**
      * Push a badge to indicate the language that owns the current item
      *

--- a/src/Extension/FluentBadgeExtension.php
+++ b/src/Extension/FluentBadgeExtension.php
@@ -3,6 +3,7 @@
 namespace TractorCow\Fluent\Extension;
 
 use SilverStripe\Core\Extension;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
@@ -11,6 +12,19 @@ use TractorCow\Fluent\State\FluentState;
 
 class FluentBadgeExtension extends Extension
 {
+
+    public function __construct()
+    {
+        Deprecation::withNoReplacement(function () {
+            Deprecation::notice(
+                '4.13.0',
+                'Will be replaced with using TractorCow\Fluent\Extension\Traits\FluentBadgeTrait on an extension instead',
+                Deprecation::SCOPE_CLASS
+            );
+        });
+
+        parent::__construct();
+    }
     /**
      * Push a badge to indicate the language that owns the current item
      *


### PR DESCRIPTION
Suggested replacement PR for https://github.com/tractorcow-farm/silverstripe-fluent/pull/782.

My motivation is to allow a high degree of support for users of new framework 4.x (e.g. 4.12/4.13) that are using fluent 4 / 5 opting to use soft-support for api that may or may not be present.

For versions of fluent that require new framework features (e.g. versioned-admin, new deprecations, php version bump) I will be happy to support dependency changes on the 6 branch, which will be the last feature branch for framework 4.x dependencies.