### PR TITLE
skip empty 'where' clauses

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -581,7 +581,11 @@ class FluentExtension extends DataExtension
 
             // Apply substitutions
             $localisedPredicate = str_replace($conditionSearch, $conditionReplace, $predicate);
-
+            
+            if (empty($localisedPredicate)) {
+                continue;
+            }
+            
             $where[$index] = [
                 $localisedPredicate => $parameters
             ];


### PR DESCRIPTION
This is a fix for both https://github.com/symbiote/silverstripe-gridfieldextensions/issues/356 and possibly https://github.com/tractorcow-farm/silverstripe-fluent/issues/257