### PR TITLE
Update FluentExtension.php

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -583,6 +583,10 @@ class FluentExtension extends DataExtension
             // Apply substitutions
             $localisedPredicate = str_replace($conditionSearch, $conditionReplace, $predicate);
 
+            if (empty($localisedPredicate)) {
+                continue;
+            }
+            
             $where[$index] = [
                 $localisedPredicate => $parameters
             ];


### PR DESCRIPTION
skip empty 'where' clauses.
just trying to make this available for SS4.