### PR TITLE
copy Bugfix for GridFieldAddExistingSearchButton from master to version 6.0

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -583,6 +583,10 @@ class FluentExtension extends DataExtension
             // Apply substitutions
             $localisedPredicate = str_replace($conditionSearch, $conditionReplace, $predicate);
 
+            if (empty($localisedPredicate)) {
+                continue;
+            }
+
             $where[$index] = [
                 $localisedPredicate => $parameters
             ];


### PR DESCRIPTION
I just copied the bugfix from this PR  #793 which solves issue from this issue: https://github.com/symbiote/silverstripe-gridfieldextensions/issues/356  to Version 6.0. 