### PR TITLE
ENH Add generic types

### DIFF
--- a/src/Extension/FluentCMSMainExtension.php
+++ b/src/Extension/FluentCMSMainExtension.php
@@ -22,7 +22,8 @@ use TractorCow\Fluent\Forms\CopyLocaleAction;
  *
  * @see FluentSiteTreeExtension::updateSavePublishActions()
  * @see CopyLocaleAction::handleAction()
- * @property CMSMain $owner
+ *
+ * @extends Extension<CMSMain>
  */
 class FluentCMSMainExtension extends Extension
 {

--- a/src/Extension/FluentChangesExtension.php
+++ b/src/Extension/FluentChangesExtension.php
@@ -8,7 +8,7 @@ use SilverStripe\Versioned\ChangeSetItem;
 /**
  * Adds locale-specific extensions to ChangeSet
  *
- * @property ChangeSetItem $owner
+ * @extends DataExtension<ChangeSetItem>
  */
 class FluentChangesExtension extends DataExtension
 {
@@ -26,7 +26,6 @@ class FluentChangesExtension extends DataExtension
         }
 
         // Mark any fluent object as modified if otherwise treated as null
-        /** @var ChangeSetItem $owner */
         $owner = $this->owner;
         foreach ($owner->Object()->getExtensionInstances() as $extension) {
             if ($extension instanceof FluentExtension) {

--- a/src/Extension/FluentDateTimeExtension.php
+++ b/src/Extension/FluentDateTimeExtension.php
@@ -8,7 +8,7 @@ use TractorCow\Fluent\Model\LocalDateTime;
 use TractorCow\Fluent\Model\Locale;
 
 /**
- * @property DBDatetime $owner
+ * @extends Extension<DBDatetime>
  */
 class FluentDateTimeExtension extends Extension
 {

--- a/src/Extension/FluentDirectorExtension.php
+++ b/src/Extension/FluentDirectorExtension.php
@@ -14,7 +14,7 @@ use TractorCow\Fluent\Model\Locale;
 /**
  * Fluent extension for {@link \SilverStripe\Control\Director} to apply routing rules for locales
  *
- * @property Director $owner
+ * @extends Extension<Director>
  */
 class FluentDirectorExtension extends Extension
 {
@@ -138,7 +138,6 @@ class FluentDirectorExtension extends Extension
     {
         $queryParam = static::config()->get('query_param');
         $rules = [];
-        /** @var Locale $localeObj */
         foreach (Locale::getCached() as $localeObj) {
             $locale = $localeObj->getLocale();
             $url = $localeObj->getURLSegment();

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -46,7 +46,8 @@ use TractorCow\Fluent\State\FluentState;
  * - data_exclude
  * - data_include
  *
- * @property FluentExtension|DataObject $owner
+ * @template T of DataObject
+ * @extends DataExtension<T&static>
  */
 class FluentExtension extends DataExtension
 {
@@ -998,13 +999,12 @@ class FluentExtension extends DataExtension
     /**
      * Templatable list of all locale information for this record
      *
-     * @return ArrayList|RecordLocale[]
+     * @return ArrayList<RecordLocale>
      */
     public function Locales()
     {
         $data = [];
         foreach (Locale::getCached() as $localeObj) {
-            /** @var Locale $localeObj */
             $data[] = $this->owner->LocaleInformation($localeObj->getLocale());
         }
         return ArrayList::create($data);

--- a/src/Extension/FluentFilteredExtension.php
+++ b/src/Extension/FluentFilteredExtension.php
@@ -17,8 +17,9 @@ use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
 
 /**
- * @property FluentFilteredExtension|DataObject $owner
  * @method DataList|Locale[] FilteredLocales()
+ *
+ * @extends DataExtension<DataObject&static>
  */
 class FluentFilteredExtension extends DataExtension
 {

--- a/src/Extension/FluentGridFieldExtension.php
+++ b/src/Extension/FluentGridFieldExtension.php
@@ -18,7 +18,7 @@ use TractorCow\Fluent\Extension\Traits\FluentBadgeTrait;
 /**
  * Supports GridFieldDetailForm_ItemRequest with extra actions
  *
- * @property GridFieldDetailForm_ItemRequest $owner
+ * @extends Extension<GridFieldDetailForm_ItemRequest>
  */
 class FluentGridFieldExtension extends Extension
 {

--- a/src/Extension/FluentIsolatedExtension.php
+++ b/src/Extension/FluentIsolatedExtension.php
@@ -17,8 +17,9 @@ use TractorCow\Fluent\State\FluentState;
  * Note: You cannot use this extension on any object with the other fluent extensions
  *
  * @property int $LocaleID
- * @property FluentIsolatedExtension|DataObject $owner
  * @method Locale Locale()
+ *
+ * @extends DataExtension<DataObject&static>
  */
 class FluentIsolatedExtension extends DataExtension
 {

--- a/src/Extension/FluentLeftAndMainExtension.php
+++ b/src/Extension/FluentLeftAndMainExtension.php
@@ -14,7 +14,7 @@ use TractorCow\Fluent\Extension\Traits\FluentAdminTrait;
 use TractorCow\Fluent\Extension\Traits\FluentBadgeTrait;
 
 /**
- * @property LeftAndMain $owner
+ * @extends Extension<LeftAndMain>
  */
 class FluentLeftAndMainExtension extends Extension
 {

--- a/src/Extension/FluentMemberExtension.php
+++ b/src/Extension/FluentMemberExtension.php
@@ -5,11 +5,15 @@ namespace TractorCow\Fluent\Extension;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\Security\Group;
+use SilverStripe\Security\Member;
 use SilverStripe\Security\Member_GroupSet;
 use SilverStripe\Security\Permission;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
 
+/**
+ * @extends DataExtension<Member>
+ */
 class FluentMemberExtension extends DataExtension
 {
     /**
@@ -46,7 +50,7 @@ class FluentMemberExtension extends DataExtension
     /**
      * Get list of locales that the user has CMS access in
      *
-     * @return Locale[]|ArrayList
+     * @return ArrayList<Locale>
      */
     public function getCMSAccessLocales()
     {
@@ -74,7 +78,6 @@ class FluentMemberExtension extends DataExtension
     protected function getLocalePermissionsForGroup(Group $group)
     {
         $localePermissions = [];
-        /** @var Permission $permission */
         foreach ($group->Permissions() as $permission) {
             $prefix = Locale::CMS_ACCESS_FLUENT_LOCALE;
             $begin = substr($permission->Code, 0, strlen($prefix));

--- a/src/Extension/FluentReadVersionsExtension.php
+++ b/src/Extension/FluentReadVersionsExtension.php
@@ -12,7 +12,7 @@ use TractorCow\Fluent\State\FluentState;
 /**
  * Available since SilverStripe 4.3.x
  *
- * @property ReadVersions $owner
+ * @extends Extension<ReadVersions>
  */
 class FluentReadVersionsExtension extends Extension
 {

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -27,7 +27,7 @@ if (!class_exists(SiteTree::class)) {
 /**
  * Fluent extension for SiteTree
  *
- * @property FluentSiteTreeExtension|SiteTree $owner
+ * @extends FluentVersionedExtension<SiteTree&static>
  */
 class FluentSiteTreeExtension extends FluentVersionedExtension
 {

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -24,7 +24,8 @@ use TractorCow\Fluent\State\FluentState;
  * Important: If adding this to a custom object, this extension must be added AFTER the versioned extension.
  * Use yaml `after` to enforce this
  *
- * @property DataObject|FluentVersionedExtension $owner
+ * @template T of DataObject&Versioned
+ * @extends FluentExtension<T&static>
  */
 class FluentVersionedExtension extends FluentExtension implements Resettable
 {
@@ -156,7 +157,6 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
      */
     public function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null)
     {
-        /** @var Locale|null $locale */
         $locale = $this->getDataQueryLocale($dataQuery);
         if (!$locale) {
             return;
@@ -228,7 +228,6 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
         $baseTable = $this->owner->baseTable();
 
         foreach ($locale->getChain() as $joinLocale) {
-            /** @var Locale $joinLocale */
             $joinAlias = $this->getLocalisedTable($tableName, $joinLocale->Locale);
             $versionTable = $baseTable . self::SUFFIX_VERSIONS;
 
@@ -386,7 +385,6 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
      */
     public function stagesDifferInLocale($locale = null): bool
     {
-        /** @var DataObject|Versioned|FluentExtension|FluentVersionedExtension $record */
         $record = $this->owner;
         $id = $record->ID ?: $record->OldID;
         $class = get_class($record);
@@ -518,7 +516,6 @@ SQL;
     {
         static::$idsInLocaleCache = [];
 
-        /** @var FluentVersionedExtension $singleton */
         $singleton = singleton(static::class);
         $singleton->flushVersionsCache();
     }
@@ -575,7 +572,6 @@ SQL;
 
         // Populate both the draft and live stages
         foreach ($tables as $table) {
-            /** @var SQLSelect $select */
             $select = SQLSelect::create(
                 ['"RecordID"'],
                 '"' . $table . '"',

--- a/src/Extension/Traits/FluentBadgeTrait.php
+++ b/src/Extension/Traits/FluentBadgeTrait.php
@@ -42,7 +42,6 @@ trait FluentBadgeTrait
      */
     public function getBadge(DataObject $record)
     {
-        /** @var Locale $currentLocale */
         $currentLocale = Locale::getCurrentLocale();
         if (!$currentLocale) {
             return null;

--- a/src/Extension/Traits/FluentObjectTrait.php
+++ b/src/Extension/Traits/FluentObjectTrait.php
@@ -16,8 +16,6 @@ use TractorCow\Fluent\State\FluentState;
 
 /**
  * Shared functionality between both FluentExtension and FluentFilteredExtension
- *
- * @property DataObject $owner
  */
 trait FluentObjectTrait
 {
@@ -41,7 +39,7 @@ trait FluentObjectTrait
     /**
      * Gets list of all Locale dataobjects, linked to this record
      *
-     * @return ArrayList|Locale[]
+     * @return ArrayList<Locale>
      * @see Locale::RecordLocale()
      */
     public function LinkedLocales()
@@ -90,7 +88,9 @@ trait FluentObjectTrait
      */
     protected function updateFluentCMSFields(FieldList $fields)
     {
-        if (!$this->owner->ID) {
+        /** @var DataObject $owner */
+        $owner = $this->owner;
+        if (!$owner->ID) {
             return;
         }
 
@@ -102,7 +102,6 @@ trait FluentObjectTrait
         // Generate gridfield for handling localisations
         $config = GridFieldConfig_Base::create();
 
-        /** @var GridFieldDataColumns $columns */
         $columns = $config->getComponentByType(GridFieldDataColumns::class);
         $summaryColumns = [
             'Title' => 'Title',
@@ -110,11 +109,11 @@ trait FluentObjectTrait
         ];
 
         // Let extensions override columns
-        $this->owner->extend('updateLocalisationTabColumns', $summaryColumns);
+        $owner->extend('updateLocalisationTabColumns', $summaryColumns);
         $columns->setDisplayFields($summaryColumns);
 
         // Let extensions override components
-        $this->owner->extend('updateLocalisationTabConfig', $config);
+        $owner->extend('updateLocalisationTabConfig', $config);
 
         // Add gridfield to tab / fields
         $gridField = GridField::create(

--- a/src/Forms/CopyLocaleAction.php
+++ b/src/Forms/CopyLocaleAction.php
@@ -116,7 +116,6 @@ class CopyLocaleAction extends BaseAction
             throw new LogicException("Error loading locale");
         }
 
-        /** @var RecordLocale $fromRecordLocale */
         $fromRecordLocale = RecordLocale::create($record, $fromLocale);
         return $fromRecordLocale->IsDraft();
     }

--- a/src/Forms/VisibleLocalesColumn.php
+++ b/src/Forms/VisibleLocalesColumn.php
@@ -68,7 +68,6 @@ class VisibleLocalesColumn implements GridField_ColumnProvider
         }
 
         $label = '';
-        /** @var Locale $locale */
         foreach (Locale::getLocales() as $locale) {
             $label .= $this->generateBadgeHTML($record, $locale);
         }

--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -286,7 +286,6 @@ class DetectLocaleMiddleware implements HTTPMiddleware
         // If the current domain has exactly one locale, the locale is non-ambiguous
         $locales = Locale::getCached()->filter('DomainID', $domainObj->ID);
         if ($locales->count() == 1) {
-            /** @var Locale $localeObject */
             $localeObject = $locales->first();
             if ($localeObject) {
                 return $localeObject->getLocale();
@@ -313,7 +312,6 @@ class DetectLocaleMiddleware implements HTTPMiddleware
             return null;
         }
 
-        /** @var LocaleDetector $detector */
         $detector = Injector::inst()->get(LocaleDetector::class);
         $localeObj = $detector->detectLocale($request);
         if ($localeObj) {
@@ -358,7 +356,6 @@ class DetectLocaleMiddleware implements HTTPMiddleware
         // If limited to one or more locales, check that the current locale is in
         // this list
         $allowedLocales = $member->getCMSAccessLocales();
-        /** @var Locale $firstAllowedLocale */
         $firstAllowedLocale = $allowedLocales->first();
         if ($firstAllowedLocale && !$allowedLocales->find('Locale', $state->getLocale())) {
             // Force state to the first allowed locale

--- a/src/Model/CachableModel.php
+++ b/src/Model/CachableModel.php
@@ -15,9 +15,8 @@ use SilverStripe\ORM\DB;
  */
 trait CachableModel
 {
-
     /**
-     * @return ArrayList|static[]
+     * @return ArrayList<static>
      */
     public static function getCached()
     {

--- a/src/Model/Delete/UsesDeletePolicy.php
+++ b/src/Model/Delete/UsesDeletePolicy.php
@@ -30,7 +30,6 @@ trait UsesDeletePolicy
         }
         $queriedTables = [];
 
-        /** @var DeletePolicy $policy */
         $policy = Injector::inst()->create(DeletePolicy::class, $this->owner);
         $policy->delete($this->owner);
     }

--- a/src/Model/Domain.php
+++ b/src/Model/Domain.php
@@ -83,7 +83,6 @@ class Domain extends DataObject
 
         // Don't show "Is Default" column, as this is not locale-specific default
         $localeConfig = GridFieldConfig_RelationEditor::create();
-        /** @var GridFieldDataColumns $detailRow */
         $detailRow = $localeConfig->getComponentByType(GridFieldDataColumns::class);
         $detailRow->setDisplayFields([
             'Title' => 'Title',
@@ -184,7 +183,7 @@ class Domain extends DataObject
     /**
      * Get locales for this domain
      *
-     * @return ArrayList|Locale[]
+     * @return ArrayList<Locale>
      */
     public function getLocales()
     {

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -43,8 +43,8 @@ use TractorCow\Fluent\State\FluentState;
  * @property int $DomainID
  * @property bool $UseDefaultCode
  * @property string $Timezone
- * @method HasManyList|FallbackLocale[] FallbackLocales()
- * @method ManyManyList|Locale[] Fallbacks()
+ * @method HasManyList<FallbackLocale> FallbackLocales()
+ * @method ManyManyList<Locale> Fallbacks()
  * @method Domain Domain() Raw SQL Domain (unfiltered by domain mode)
  */
 class Locale extends DataObject implements PermissionProvider
@@ -128,7 +128,7 @@ class Locale extends DataObject implements PermissionProvider
     ];
 
     /**
-     * @var ArrayList
+     * @var ArrayList<Locale>
      */
     protected $chain = null;
 
@@ -486,7 +486,7 @@ class Locale extends DataObject implements PermissionProvider
      *
      * @param string|null|true $domain If provided, locales for the given domain will be returned.
      *                                 If true, then the current state domain will be used (if in domain mode).
-     * @return ArrayList|Locale[]
+     * @return ArrayList<Locale>
      */
     public static function getLocales($domain = null)
     {
@@ -516,7 +516,7 @@ class Locale extends DataObject implements PermissionProvider
     /**
      * Get chain of all locales that should be preferred when this locale is current
      *
-     * @return ArrayList
+     * @return ArrayList<Locale>
      */
     public function getChain()
     {
@@ -589,7 +589,7 @@ class Locale extends DataObject implements PermissionProvider
     /**
      * Get other locales that appear alongside this (including self)
      *
-     * @return ArrayList
+     * @return ArrayList<Locale>
      */
     public function getSiblingLocales()
     {

--- a/src/Model/RecordLocale.php
+++ b/src/Model/RecordLocale.php
@@ -372,7 +372,6 @@ class RecordLocale extends ViewableData
             return $this->getLocaleObject();
         }
 
-        /** @var Locale $fallback */
         foreach ($this->getLocaleObject()->Fallbacks() as $fallback) {
             if (!$record->existsInLocale($fallback->Locale)) {
                 continue;

--- a/src/State/BrowserLocaleDetector.php
+++ b/src/State/BrowserLocaleDetector.php
@@ -60,7 +60,6 @@ class BrowserLocaleDetector implements LocaleDetector
         foreach ($prioritisedLocales as $priority => $parsedLocales) {
             foreach ($parsedLocales as $browserLocale) {
                 foreach ($locales as $localeObj) {
-                    /** @var Locale $localeObj */
                     if ($localeObj->isLocale($browserLocale)) {
                         return $localeObj;
                     }

--- a/src/Task/ConvertTranslatableTask.php
+++ b/src/Task/ConvertTranslatableTask.php
@@ -130,8 +130,6 @@ class ConvertTranslatableTask extends BuildTask
                         ));
 
                         foreach ($instances as $instance) {
-                            /** @var DataObject $instance */
-
                             // Get the Locale column directly from the base table, since the SS ORM will not include it
                             $instanceLocale = SQLSelect::create()
                                 ->setFrom("\"{$baseTable}\"")

--- a/src/Task/InitialPageLocalisationTask.php
+++ b/src/Task/InitialPageLocalisationTask.php
@@ -37,7 +37,6 @@ class InitialPageLocalisationTask extends BuildTask
         $publish = (bool) $request->getVar('publish');
         $limit = (int) $request->getVar('limit');
 
-        /** @var Locale $globalLocale */
         $globalLocale = Locale::get()
             ->filter(['IsGlobalDefault' => 1])
             ->sort('ID', 'ASC')


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
- Add generic types where appropriate, e.g. for indicating the type of records inside DataList or ArrayList.
- Replace `@property` annotation for extension $owner property with a generic extension. This works effectively the same way, with the bonus benefit that the return type for getOwner() is also correct.
- Remove unnecessary `@var` comments.

Requires https://github.com/silverstripe/silverstripe-framework/pull/11108 for these generics to take effect.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
You can validate that the types are evaluating correctly in your preferred code editor.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11066

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] Tests aren't necessary for this change
- [x] CI is green
