### PR TITLE
FIX allows i18nTextCollector to concatenate keys

### DIFF
--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -107,7 +107,7 @@ trait FluentAdminTrait
         // Add menu button
         $moreOptions = Tab::create(
             'FluentMenuOptions',
-            _t(__TRAIT__ . '.Localisation', 'Localisation')
+            _t('FluentAdminTrait.Localisation', 'Localisation')
         );
         $moreOptions->addExtraClass('popover-actions-simulate');
         $rootTabSet->push($moreOptions);
@@ -117,7 +117,7 @@ trait FluentAdminTrait
             FormAction::create(
                 'clearFluent',
                 _t(
-                    __TRAIT__ . '.Label_clearFluent',
+                    'FluentAdminTrait.Label_clearFluent',
                     "Clear from all except '{title}'",
                     [
                         'title' => $locale->getTitle()
@@ -129,7 +129,7 @@ trait FluentAdminTrait
             FormAction::create(
                 'copyFluent',
                 _t(
-                    __TRAIT__ . '.Label_copyFluent',
+                    'FluentAdminTrait.Label_copyFluent',
                     "Copy '{title}' to other locales",
                     [
                         'title' => $locale->getTitle()
@@ -144,7 +144,7 @@ trait FluentAdminTrait
                 FormAction::create(
                     'unpublishFluent',
                     _t(
-                        __TRAIT__ . '.Label_unpublishFluent',
+                        'FluentAdminTrait.Label_unpublishFluent',
                         'Unpublish (all locales)'
                     )
                 )->addExtraClass('btn-secondary')
@@ -153,7 +153,7 @@ trait FluentAdminTrait
                 FormAction::create(
                     'archiveFluent',
                     _t(
-                        __TRAIT__ . '.Label_archiveFluent',
+                        'FluentAdminTrait.Label_archiveFluent',
                         'Unpublish and Archive (all locales)'
                     )
                 )->addExtraClass('btn-outline-danger')
@@ -162,7 +162,7 @@ trait FluentAdminTrait
                 FormAction::create(
                     'publishFluent',
                     _t(
-                        __TRAIT__ . '.Label_publishFluent',
+                        'FluentAdminTrait.Label_publishFluent',
                         'Save & Publish (all locales)'
                     )
                 )->addExtraClass('btn-primary')
@@ -172,7 +172,7 @@ trait FluentAdminTrait
                 FormAction::create(
                     'deleteFluent',
                     _t(
-                        __TRAIT__ . '.Label_deleteFluent',
+                        'FluentAdminTrait.Label_deleteFluent',
                         'Delete (all locales)'
                     )
                 )->addExtraClass('btn-outline-danger')
@@ -187,7 +187,7 @@ trait FluentAdminTrait
                     FormAction::create(
                         'hideFluent',
                         _t(
-                            __TRAIT__ . '.Label_hideFluent',
+                            'FluentAdminTrait.Label_hideFluent',
                             "Hide from '{title}'",
                             [
                                 'title' => $locale->getTitle()
@@ -200,7 +200,7 @@ trait FluentAdminTrait
                     FormAction::create(
                         'showFluent',
                         _t(
-                            __TRAIT__ . '.Label_showFluent',
+                            'FluentAdminTrait.Label_showFluent',
                             "Show in '{title}'",
                             [
                                 'title' => $locale->getTitle()
@@ -256,7 +256,7 @@ trait FluentAdminTrait
         });
 
         $message = _t(
-            __TRAIT__ . '.ClearAllNotice',
+            'FluentAdminTrait.ClearAllNotice',
             "All localisations have been cleared for '{title}'.",
             ['title' => $record->Title]
         );
@@ -292,7 +292,7 @@ trait FluentAdminTrait
             if ($locale->ID == $originalLocale->ID) {
                 return;
             }
-            
+
             if ($record->hasExtension(Versioned::class)) {
                 $record->writeToStage(Versioned::DRAFT);
             } else {
@@ -302,7 +302,7 @@ trait FluentAdminTrait
         });
 
         $message = _t(
-            __TRAIT__ . '.CopyNotice',
+            'FluentAdminTrait.CopyNotice',
             "Copied '{title}' to all other locales.",
             ['title' => $record->Title]
         );
@@ -336,7 +336,7 @@ trait FluentAdminTrait
         });
 
         $message = _t(
-            __TRAIT__ . '.UnpublishNotice',
+            'FluentAdminTrait.UnpublishNotice',
             "Unpublished '{title}' from all locales.",
             ['title' => $record->Title]
         );
@@ -386,7 +386,7 @@ trait FluentAdminTrait
         $policy->delete($record);
 
         $message = _t(
-            __TRAIT__ . '.ArchiveNotice',
+            'FluentAdminTrait.ArchiveNotice',
             "Archived '{title}' and all of its localisations.",
             ['title' => $record->Title]
         );
@@ -434,7 +434,7 @@ trait FluentAdminTrait
         $policy->delete($record);
 
         $message = _t(
-            __TRAIT__ . '.DeleteNotice',
+            'FluentAdminTrait.DeleteNotice',
             "Deleted '{title}' and all of its localisations.",
             ['title' => $record->Title]
         );
@@ -478,7 +478,7 @@ trait FluentAdminTrait
         });
 
         $message = _t(
-            __TRAIT__ . '.PublishNotice',
+            'FluentAdminTrait.PublishNotice',
             "Published '{title}' across all locales.",
             ['title' => $record->Title]
         );
@@ -508,7 +508,7 @@ trait FluentAdminTrait
         $record->FilteredLocales()->add($locale);
 
         $message = _t(
-            __TRAIT__ . '.ShowNotice',
+            'FluentAdminTrait.ShowNotice',
             "Record '{title}' is now visible in {locale}",
             [
                 'title'  => $record->Title,
@@ -541,7 +541,7 @@ trait FluentAdminTrait
         $record->FilteredLocales()->remove($locale);
 
         $message = _t(
-            __TRAIT__ . '.HideNotice',
+            'FluentAdminTrait.HideNotice',
             "Record '{title}' is now hidden in {locale}",
             [
                 'title'  => $record->Title,

--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -107,7 +107,7 @@ trait FluentAdminTrait
         // Add menu button
         $moreOptions = Tab::create(
             'FluentMenuOptions',
-            _t('FluentAdminTrait.Localisation', 'Localisation')
+            _t('TractorCow\Fluent\Extension\Traits\FluentAdminTrait.Localisation', 'Localisation')
         );
         $moreOptions->addExtraClass('popover-actions-simulate');
         $rootTabSet->push($moreOptions);
@@ -117,7 +117,7 @@ trait FluentAdminTrait
             FormAction::create(
                 'clearFluent',
                 _t(
-                    'FluentAdminTrait.Label_clearFluent',
+                    'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.Label_clearFluent',
                     "Clear from all except '{title}'",
                     [
                         'title' => $locale->getTitle()
@@ -129,7 +129,7 @@ trait FluentAdminTrait
             FormAction::create(
                 'copyFluent',
                 _t(
-                    'FluentAdminTrait.Label_copyFluent',
+                    'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.Label_copyFluent',
                     "Copy '{title}' to other locales",
                     [
                         'title' => $locale->getTitle()
@@ -144,7 +144,7 @@ trait FluentAdminTrait
                 FormAction::create(
                     'unpublishFluent',
                     _t(
-                        'FluentAdminTrait.Label_unpublishFluent',
+                        'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.Label_unpublishFluent',
                         'Unpublish (all locales)'
                     )
                 )->addExtraClass('btn-secondary')
@@ -153,7 +153,7 @@ trait FluentAdminTrait
                 FormAction::create(
                     'archiveFluent',
                     _t(
-                        'FluentAdminTrait.Label_archiveFluent',
+                        'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.Label_archiveFluent',
                         'Unpublish and Archive (all locales)'
                     )
                 )->addExtraClass('btn-outline-danger')
@@ -162,7 +162,7 @@ trait FluentAdminTrait
                 FormAction::create(
                     'publishFluent',
                     _t(
-                        'FluentAdminTrait.Label_publishFluent',
+                        'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.Label_publishFluent',
                         'Save & Publish (all locales)'
                     )
                 )->addExtraClass('btn-primary')
@@ -172,7 +172,7 @@ trait FluentAdminTrait
                 FormAction::create(
                     'deleteFluent',
                     _t(
-                        'FluentAdminTrait.Label_deleteFluent',
+                        'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.Label_deleteFluent',
                         'Delete (all locales)'
                     )
                 )->addExtraClass('btn-outline-danger')
@@ -187,7 +187,7 @@ trait FluentAdminTrait
                     FormAction::create(
                         'hideFluent',
                         _t(
-                            'FluentAdminTrait.Label_hideFluent',
+                            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.Label_hideFluent',
                             "Hide from '{title}'",
                             [
                                 'title' => $locale->getTitle()
@@ -200,7 +200,7 @@ trait FluentAdminTrait
                     FormAction::create(
                         'showFluent',
                         _t(
-                            'FluentAdminTrait.Label_showFluent',
+                            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.Label_showFluent',
                             "Show in '{title}'",
                             [
                                 'title' => $locale->getTitle()
@@ -256,7 +256,7 @@ trait FluentAdminTrait
         });
 
         $message = _t(
-            'FluentAdminTrait.ClearAllNotice',
+            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.ClearAllNotice',
             "All localisations have been cleared for '{title}'.",
             ['title' => $record->Title]
         );
@@ -302,7 +302,7 @@ trait FluentAdminTrait
         });
 
         $message = _t(
-            'FluentAdminTrait.CopyNotice',
+            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.CopyNotice',
             "Copied '{title}' to all other locales.",
             ['title' => $record->Title]
         );
@@ -336,7 +336,7 @@ trait FluentAdminTrait
         });
 
         $message = _t(
-            'FluentAdminTrait.UnpublishNotice',
+            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.UnpublishNotice',
             "Unpublished '{title}' from all locales.",
             ['title' => $record->Title]
         );
@@ -386,7 +386,7 @@ trait FluentAdminTrait
         $policy->delete($record);
 
         $message = _t(
-            'FluentAdminTrait.ArchiveNotice',
+            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.ArchiveNotice',
             "Archived '{title}' and all of its localisations.",
             ['title' => $record->Title]
         );
@@ -434,7 +434,7 @@ trait FluentAdminTrait
         $policy->delete($record);
 
         $message = _t(
-            'FluentAdminTrait.DeleteNotice',
+            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.DeleteNotice',
             "Deleted '{title}' and all of its localisations.",
             ['title' => $record->Title]
         );
@@ -478,7 +478,7 @@ trait FluentAdminTrait
         });
 
         $message = _t(
-            'FluentAdminTrait.PublishNotice',
+            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.PublishNotice',
             "Published '{title}' across all locales.",
             ['title' => $record->Title]
         );
@@ -508,7 +508,7 @@ trait FluentAdminTrait
         $record->FilteredLocales()->add($locale);
 
         $message = _t(
-            'FluentAdminTrait.ShowNotice',
+            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.ShowNotice',
             "Record '{title}' is now visible in {locale}",
             [
                 'title'  => $record->Title,
@@ -541,7 +541,7 @@ trait FluentAdminTrait
         $record->FilteredLocales()->remove($locale);
 
         $message = _t(
-            'FluentAdminTrait.HideNotice',
+            'TractorCow\Fluent\Extension\Traits\FluentAdminTrait.HideNotice',
             "Record '{title}' is now hidden in {locale}",
             [
                 'title'  => $record->Title,

--- a/src/Extension/Traits/FluentBadgeTrait.php
+++ b/src/Extension/Traits/FluentBadgeTrait.php
@@ -76,7 +76,7 @@ trait FluentBadgeTrait
             // If the object has been localised in the current locale, show a "localised" state
             $badgeClasses[] = 'fluent-badge--default';
             $tooltip = _t(
-                __TRAIT__ . '.BadgeLocalised',
+                'FluentBadgeTrait.BadgeLocalised',
                 'Localised in {locale}',
                 [
                     'locale' => $locale->getTitle()
@@ -86,7 +86,7 @@ trait FluentBadgeTrait
             // If object is inheriting content from another locale show the source
             $badgeClasses[] = 'fluent-badge--localised';
             $tooltip = _t(
-                __TRAIT__ . '.BadgeInherited',
+                'FluentBadgeTrait.BadgeInherited',
                 'Inherited from {locale}',
                 [
                     'locale' => $info->getSourceLocale()->getTitle()
@@ -97,7 +97,7 @@ trait FluentBadgeTrait
             // by either localising or seting up a locale fallback
             $badgeClasses[] = 'fluent-badge--invisible';
             $tooltip = _t(
-                __TRAIT__ . '.BaggeInvisible',
+                'FluentBadgeTrait.BaggeInvisible',
                 '{type} has no available content in {locale}, localise the {type} or provide a locale fallback',
                 [
                     'type' => $record->i18n_singular_name(),

--- a/src/Extension/Traits/FluentBadgeTrait.php
+++ b/src/Extension/Traits/FluentBadgeTrait.php
@@ -76,7 +76,7 @@ trait FluentBadgeTrait
             // If the object has been localised in the current locale, show a "localised" state
             $badgeClasses[] = 'fluent-badge--default';
             $tooltip = _t(
-                'FluentBadgeTrait.BadgeLocalised',
+                'TractorCow\Fluent\Extension\Traits\FluentBadgeTrait.BadgeLocalised',
                 'Localised in {locale}',
                 [
                     'locale' => $locale->getTitle()
@@ -86,7 +86,7 @@ trait FluentBadgeTrait
             // If object is inheriting content from another locale show the source
             $badgeClasses[] = 'fluent-badge--localised';
             $tooltip = _t(
-                'FluentBadgeTrait.BadgeInherited',
+                'TractorCow\Fluent\Extension\Traits\FluentBadgeTrait.BadgeInherited',
                 'Inherited from {locale}',
                 [
                     'locale' => $info->getSourceLocale()->getTitle()
@@ -97,7 +97,7 @@ trait FluentBadgeTrait
             // by either localising or seting up a locale fallback
             $badgeClasses[] = 'fluent-badge--invisible';
             $tooltip = _t(
-                'FluentBadgeTrait.BaggeInvisible',
+                'TractorCow\Fluent\Extension\Traits\FluentBadgeTrait.BaggeInvisible',
                 '{type} has no available content in {locale}, localise the {type} or provide a locale fallback',
                 [
                     'type' => $record->i18n_singular_name(),

--- a/src/Extension/Traits/FluentObjectTrait.php
+++ b/src/Extension/Traits/FluentObjectTrait.php
@@ -128,7 +128,7 @@ trait FluentObjectTrait
 
             $fields
                 ->fieldByName('Root.Locales')
-                ->setTitle(_t('FluentObjectTrait.TAB_LOCALISATION', 'Localisation'));
+                ->setTitle(_t('TractorCow\Fluent\Extension\Traits\FluentObjectTrait.TAB_LOCALISATION', 'Localisation'));
         } else {
             $fields->push($gridField);
         }

--- a/src/Extension/Traits/FluentObjectTrait.php
+++ b/src/Extension/Traits/FluentObjectTrait.php
@@ -128,7 +128,7 @@ trait FluentObjectTrait
 
             $fields
                 ->fieldByName('Root.Locales')
-                ->setTitle(_t(__TRAIT__ . '.TAB_LOCALISATION', 'Localisation'));
+                ->setTitle(_t('FluentObjectTrait.TAB_LOCALISATION', 'Localisation'));
         } else {
             $fields->push($gridField);
         }


### PR DESCRIPTION
## Description

fixes #823 - The magic constant __TRAIT__ was inserting namespaces into localization keys, containing slashes that could not be parsed by the TextCollector task. These have been replaced w/ the Trait name as a string

## Manual testing steps
Run `/dev/tasks/i18nTextCollectorTask` with the environment set to Dev or error reporting otherwise configured to display warnings.

## Issues
#823 

