### PR TITLE
fix: don't invoke db for ready check outside of dev urls

### DIFF
--- a/src/Model/CachableModel.php
+++ b/src/Model/CachableModel.php
@@ -2,6 +2,8 @@
 
 namespace TractorCow\Fluent\Model;
 
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
@@ -69,6 +71,13 @@ trait CachableModel
      */
     protected static function databaseIsReady()
     {
+        // Outside of dev/ don't actually do any checks, assume ready
+        /** @var HTTPRequest $request */
+        $request = Injector::inst()->get(HTTPRequest::class);
+        if (stripos($request->getURL(false), 'dev/') !== 0) {
+            return true;
+        }
+
         $object = DataObject::singleton(static::class);
 
         // if any of the tables aren't created in the database

--- a/src/Model/CachableModel.php
+++ b/src/Model/CachableModel.php
@@ -2,7 +2,6 @@
 
 namespace TractorCow\Fluent\Model;
 
-use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;


### PR DESCRIPTION
fixes #828

This maintains the check for DB, but it only invokes it during dev/build, which is when this check is necessary. Otherwise we assume the DB is ready for day to day use.

Replaces https://github.com/tractorcow-farm/silverstripe-fluent/pull/830