### PR TITLE
ENH: Localisation manager links available for CMS edit link capable models.

### DIFF
--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -8,12 +8,10 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Core\Convert;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\LiteralField;
-use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use TractorCow\Fluent\Extension\Traits\FluentAdminTrait;
 use TractorCow\Fluent\Model\Locale;
@@ -527,61 +525,5 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     public function actionComplete($form, $message)
     {
         return null;
-    }
-
-    /**
-     * Augment Localisation tab with clickable locale links to allow easy navigation between page localisations
-     *
-     * @param $summaryColumns
-     * @see FluentExtension::updateFluentCMSFields()
-     */
-    public function updateLocalisationTabColumns(&$summaryColumns)
-    {
-        parent::updateLocalisationTabColumns($summaryColumns);
-
-        if (!array_key_exists('Title', $summaryColumns)) {
-            return;
-        }
-
-        $controller = Controller::curr();
-
-        if (!$controller) {
-            return;
-        }
-
-        $request = $controller->getRequest();
-
-        if (!$request) {
-            return;
-        }
-
-        // This is to get URL only, getVars are not part of the URL
-        $url = $this->owner->CMSEditLink();
-
-        if (!$url) {
-            return;
-        }
-
-        // Pass getVars separately so we can process them later
-        $params = $request->getVars();
-        $url = Director::makeRelative($url);
-
-        $summaryColumns['Title'] = [
-            'title' => 'Title',
-            'callback' => function (Locale $object) use ($url, $params) {
-                if (!$object->RecordLocale()) {
-                    return null;
-                }
-
-                $recordLocale = $object->RecordLocale();
-                $locale = $recordLocale->getLocale();
-                $params['l'] = $locale;
-                $localeLink = Controller::join_links($url, '?' . http_build_query($params));
-                $localeTitle = Convert::raw2xml($recordLocale->getTitle());
-                $render = sprintf('<a href="%s" target="_top">%s</a>', $localeLink, $localeTitle);
-
-                return DBField::create_field('HTMLVarchar', $render);
-            }
-        ];
     }
 }

--- a/src/Extension/Traits/FluentObjectTrait.php
+++ b/src/Extension/Traits/FluentObjectTrait.php
@@ -125,23 +125,25 @@ trait FluentObjectTrait
             $url = $owner->CMSEditLink();
             $url = Director::makeRelative($url);
 
-            $summaryColumns['Title'] = [
-                'title' => 'Title',
-                'callback' => function (Locale $object) use ($url, $params): ?DBField {
-                    if (!$object->RecordLocale()) {
-                        return null;
+            if ($url) {
+                $summaryColumns['Title'] = [
+                    'title' => 'Title',
+                    'callback' => function (Locale $object) use ($url, $params): ?DBField {
+                        if (!$object->RecordLocale()) {
+                            return null;
+                        }
+
+                        $recordLocale = $object->RecordLocale();
+                        $locale = $recordLocale->getLocale();
+                        $params['l'] = $locale;
+                        $localeLink = Controller::join_links($url, '?' . http_build_query($params));
+                        $localeTitle = Convert::raw2xml($recordLocale->getTitle());
+                        $render = sprintf('<a href="%s" target="_top">%s</a>', $localeLink, $localeTitle);
+
+                        return DBField::create_field('HTMLVarchar', $render);
                     }
-
-                    $recordLocale = $object->RecordLocale();
-                    $locale = $recordLocale->getLocale();
-                    $params['l'] = $locale;
-                    $localeLink = Controller::join_links($url, '?' . http_build_query($params));
-                    $localeTitle = Convert::raw2xml($recordLocale->getTitle());
-                    $render = sprintf('<a href="%s" target="_top">%s</a>', $localeLink, $localeTitle);
-
-                    return DBField::create_field('HTMLVarchar', $render);
-                }
-            ];
+                ];
+            }
         }
 
         // Let extensions override columns


### PR DESCRIPTION
## Description

Allow all CMS edit link capable models to use a Title link in the Locale manager. This link is quite handy as you can switch between locales easily. Previously this was available only for models extending `SiteTree` (pages).

![Screenshot 2024-04-05 at 11 35 15 AM](https://github.com/tractorcow-farm/silverstripe-fluent/assets/26395487/24c993d8-8ac2-4704-8a61-694797fa6d64)

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
