### PR TITLE
FIX: Source locale indicator correction.

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -25,7 +25,6 @@ use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\ORM\Queries\SQLConditionGroup;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\ORM\ValidationException;
-use SilverStripe\Security\Permission;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\HTML;
 use TractorCow\Fluent\Extension\Traits\FluentObjectTrait;
@@ -992,19 +991,24 @@ class FluentExtension extends DataExtension
         return Locale::getCurrentLocale();
     }
 
-
     /**
      * Returns the source locale that will display the content for this record
      *
      * @return Locale|null
      */
-    public function getSourceLocale()
+    public function getSourceLocale(): ?Locale
     {
-        $sourceLocale = $this->owner->getField('SourceLocale');
-        if ($sourceLocale) {
-            return Locale::getByLocale($sourceLocale);
+        $currentLocale = FluentState::singleton()->getLocale();
+
+        // We do not have any locales set up yet, so there is no source locale to find
+        if (!$currentLocale) {
+            return null;
         }
-        return Locale::getDefault();
+
+        $owner = $this->owner;
+        $localeInformation = $owner->LocaleInformation($currentLocale);
+
+        return $localeInformation->getSourceLocale();
     }
 
     /**
@@ -1311,11 +1315,21 @@ class FluentExtension extends DataExtension
         $summaryColumns['Source'] = [
             'title'    => 'Source',
             'callback' => function (Locale $object) {
-                if (!$object->RecordLocale()) {
+                $localeInformation = $object->RecordLocale();
+
+                if (!$localeInformation) {
                     return '';
                 }
 
-                $sourceLocale = $object->RecordLocale()->getSourceLocale();
+                $sourceLocale = FluentState::singleton()->withState(
+                    static function (FluentState $state) use ($localeInformation): ?Locale {
+                        // We are currently in the CMS context, but we want to show to the content author
+                        // what the data state is in the frontend context
+                        $state->setIsFrontend(true);
+
+                        return $localeInformation->getSourceLocale();
+                    }
+                );
 
                 if ($sourceLocale) {
                     return $sourceLocale->getLongTitle();

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -996,7 +996,7 @@ class FluentExtension extends DataExtension
      *
      * @return Locale|null
      */
-    public function getSourceLocale(): ?Locale
+    public function getSourceLocale()
     {
         $currentLocale = FluentState::singleton()->getLocale();
 

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -616,11 +616,21 @@ SQL;
         $summaryColumns['Source'] = [
             'title' => 'Source',
             'callback' => function (Locale $object) {
-                if (!$object->RecordLocale()) {
+                $localeInformation = $object->RecordLocale();
+
+                if (!$localeInformation) {
                     return '';
                 }
 
-                $sourceLocale = $object->RecordLocale()->getSourceLocale();
+                $sourceLocale = FluentState::singleton()->withState(
+                    static function (FluentState $state) use ($localeInformation): ?Locale {
+                        // We are currently in the CMS context, but we want to show to the content author
+                        // what the data state is in the frontend context
+                        $state->setIsFrontend(true);
+
+                        return $localeInformation->getSourceLocale();
+                    }
+                );
 
                 if ($sourceLocale) {
                     return $sourceLocale->getLongTitle();

--- a/src/Extension/Traits/FluentBadgeTrait.php
+++ b/src/Extension/Traits/FluentBadgeTrait.php
@@ -9,6 +9,7 @@ use TractorCow\Fluent\Extension\FluentExtension;
 use TractorCow\Fluent\Extension\FluentFilteredExtension;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\Model\RecordLocale;
+use TractorCow\Fluent\State\FluentState;
 
 trait FluentBadgeTrait
 {
@@ -68,6 +69,15 @@ trait FluentBadgeTrait
         $extraProperties = []
     ) {
         $info = RecordLocale::create($record, $locale);
+        $sourceLocale = FluentState::singleton()->withState(
+            static function (FluentState $state) use ($info): ?Locale {
+                // We are currently in the CMS context, but we want to show to the content author
+                // what the data state is in the frontend context
+                $state->setIsFrontend(true);
+
+                return $info->getSourceLocale();
+            }
+        );
 
         // Build new badge
         $badgeClasses = ['badge', 'fluent-badge'];
@@ -81,14 +91,14 @@ trait FluentBadgeTrait
                     'locale' => $locale->getTitle()
                 ]
             );
-        } elseif ($info->getSourceLocale()) {
+        } elseif ($sourceLocale) {
             // If object is inheriting content from another locale show the source
             $badgeClasses[] = 'fluent-badge--localised';
             $tooltip = _t(
                 'TractorCow\Fluent\Extension\Traits\FluentBadgeTrait.BadgeInherited',
                 'Inherited from {locale}',
                 [
-                    'locale' => $info->getSourceLocale()->getTitle()
+                    'locale' => $sourceLocale->getTitle()
                 ]
             );
         } else {

--- a/tests/php/Extension/LocaleInheritanceTest.php
+++ b/tests/php/Extension/LocaleInheritanceTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Extension;
+
+use Page;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Versioned\Versioned;
+use TractorCow\Fluent\Extension\FluentExtension;
+use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
+use TractorCow\Fluent\State\FluentState;
+
+class LocaleInheritanceTest extends SapphireTest
+{
+    protected static $fixture_file = 'LocaleInheritanceTest.yml';
+
+    protected static $required_extensions = [
+        SiteTree::class => [
+            FluentSiteTreeExtension::class,
+        ],
+    ];
+
+    /**
+     * @param string $cmsInheritanceMode
+     * @param string $frontendInheritanceMode
+     * @param bool $frontendContext
+     * @param string $locale
+     * @param string|null $expected
+     * @return void
+     * @throws ValidationException
+     * @dataProvider sourceLocaleCasesProvider
+     */
+    public function testGetSourceLocale(
+        string $cmsInheritanceMode,
+        string $frontendInheritanceMode,
+        bool $frontendContext,
+        string $locale,
+        ?string $expected
+    ): void {
+        Page::config()
+            ->set('cms_localisation_required', $cmsInheritanceMode)
+            ->set('frontend_publish_required', $frontendInheritanceMode);
+
+        Versioned::withVersionedMode(function () use ($frontendContext, $locale, $expected): void {
+            // Make sure we have the correct stage set
+            Versioned::set_stage(Versioned::DRAFT);
+
+            // Create the page in the default locale
+            FluentState::singleton()->withState(
+                function (FluentState $state) use ($frontendContext, $locale, $expected): void {
+                    $state
+                        ->setLocale('en_US')
+                        ->setIsFrontend($frontendContext);
+
+                    /** @var Page|FluentExtension $page */
+                    $page = Page::create();
+                    $page->Title = 'Page title';
+                    $page->URLSegment = 'test-page';
+                    $page->write();
+
+                    $localeInformation = $page->LocaleInformation($locale);
+                    $sourceLocaleObject = $localeInformation->getSourceLocale();
+                    $sourceLocale = $sourceLocaleObject?->Locale;
+                    $this->assertEquals(
+                        $expected,
+                        $sourceLocale,
+                        'We expect a specific source locale (locale information)'
+                    );
+
+                    if (!$sourceLocale) {
+                        return;
+                    }
+
+                    // Re-fetch the page in the target locale
+                    $state->setLocale($locale);
+
+                    /** @var Page|FluentExtension $page */
+                    $page = Page::get()->byID($page->ID);
+
+                    $this->assertNotNull($page, 'We expect the page to be available in this locale');
+                    $sourceLocaleObject = $page->getSourceLocale();
+                    $this->assertEquals(
+                        $expected,
+                        $sourceLocaleObject->Locale,
+                        'We expect a specific source locale (page shorthand method)'
+                    );
+                }
+            );
+        });
+    }
+
+    public function sourceLocaleCasesProvider(): array
+    {
+        return [
+            'default locale, cms with any mode, frontend with any mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_ANY,
+                true,
+                'en_US',
+                'en_US',
+            ],
+            'default locale, cms with exact mode, frontend with any mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                FluentExtension::INHERITANCE_MODE_ANY,
+                true,
+                'en_US',
+                'en_US',
+            ],
+            'default locale, cms with any mode, frontend with exact mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                true,
+                'en_US',
+                'en_US',
+            ],
+            'fallback locale, cms with any mode, frontend with any mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_ANY,
+                true,
+                'de_DE',
+                'en_US',
+            ],
+            'fallback locale, cms with exact mode, frontend with any mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                FluentExtension::INHERITANCE_MODE_ANY,
+                true,
+                'de_DE',
+                'en_US',
+            ],
+            'fallback locale, cms with any mode, frontend with exact mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                true,
+                'de_DE',
+                null,
+            ],
+            'fallback locale, cms with any mode, frontend with fallback mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_FALLBACK,
+                true,
+                'de_DE',
+                'en_US',
+            ],
+            'fallback locale, cms with any mode, frontend with exact mode, cms context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                false,
+                'de_DE',
+                'en_US',
+            ],
+            'no fallback locale, cms with any mode, frontend with any mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_ANY,
+                true,
+                'es_ES',
+                null,
+            ],
+            'no fallback locale, cms with exact mode, frontend with any mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                FluentExtension::INHERITANCE_MODE_ANY,
+                true,
+                'es_ES',
+                null,
+            ],
+            'no fallback locale, cms with any mode, frontend with exact mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                true,
+                'es_ES',
+                null,
+            ],
+            'no fallback locale, cms with any mode, frontend with fallback mode, frontend context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_FALLBACK,
+                true,
+                'es_ES',
+                null,
+            ],
+            'no fallback locale, cms with any mode, frontend with exact mode, cms context' => [
+                FluentExtension::INHERITANCE_MODE_ANY,
+                FluentExtension::INHERITANCE_MODE_EXACT,
+                false,
+                'es_ES',
+                null,
+            ],
+        ];
+    }
+}

--- a/tests/php/Extension/LocaleInheritanceTest.yml
+++ b/tests/php/Extension/LocaleInheritanceTest.yml
@@ -1,0 +1,13 @@
+TractorCow\Fluent\Model\Locale:
+  default:
+    Title: US English
+    Locale: en_US
+    IsGlobalDefault: true
+  german:
+    Title: German
+    Locale: de_DE
+    Fallbacks:
+      - =>TractorCow\Fluent\Model\Locale.default
+  spanish:
+    Title: Spanish
+    Locale: es_ES


### PR DESCRIPTION
# FIX: Source locale indicator correction.

## Description

Source locale detection corrected to take into account locale inheritance settings for a specific model. Impacted methods are only used in the CMS UI to give indication to content authors on what to expect (what is the source locale of the content). Before this change the indicator could be inaccurate in a sense that it would indicate content and there would actually not be any content to display.

![319797975-24c993d8-8ac2-4704-8a61-694797fa6d64](https://github.com/tractorcow-farm/silverstripe-fluent/assets/26395487/c10e8e76-e298-4e5d-bcf9-4ff27a45b03f)

This change should have no impact on actual content rendering.

**Change-set breakdown**

* `RecordLocale::getSourceLocale()` now takes into account locale inheritance mode
* `FluentExtension::getSourceLocale()` is now only a shorthand method to the above method instead of maintaining its own implementation that doesn't cover all the cases

## Manual testing steps

* assumes CMS 5 installer + Fluent
* navigate to the CMS under locales admin
* create first locale - English (Any english) and set this locale to be the global default
* create second locale - German and set the this locale to fall back to the first locale
* create a campaign page (code snippet below)

```php
class CampaignPage extends Page
{
    private static string $frontend_publish_required = FluentExtension::INHERITANCE_MODE_EXACT;
}
```

* run dev/build with flush
* reload the CMS admin pages and navigate to the pages section
* make sure you are in the English locale (see locale selector in the top left)
* create a campaign page (fill any data in)
* navigate to the localisation manager tab within the campaign page edit form
* you should see two records displayed (one for each locale)
* check the source locale for the German locale for this campaign page
* the expected value is "No source" (state after the change), before this change-set it would show English locale

Most common scenarios:

* Page uses fallback inheritance mode (default)
* Assets use any inheritance mode
* Campaign pages use exact inheritance mode

The source locale indicator should be in line with what is shown on the frontend.

## Issues

- https://github.com/tractorcow-farm/silverstripe-fluent/issues/842

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
