### PR TITLE
ENH: Explicit configuration API properties.

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -2,11 +2,6 @@
 Name: fluentmodel
 ---
 SilverStripe\ORM\DataObject:
-  # See FluentExtension
-  cms_localisation_required: any
-  frontend_publish_required: fallback
-  # See FluentFilteredExtension
-  apply_filtered_locales_to_stage: true
   # See FluentIsolatedExtension
   apply_isolated_locales_to_admin: true # Set to false to disable entirely in CMS
   apply_isolated_locales_to_byid: true # Set to false to disable for id/fk filters in CMS

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -92,7 +92,7 @@ class FluentExtension extends DataExtension
      * @var string
      * @config
      */
-    private static string $cms_localisation_required = self::INHERITANCE_MODE_ANY;
+    private static string $cms_localisation_required = FluentExtension::INHERITANCE_MODE_ANY;
 
     /**
      * Fluent inheritance mode for frontend context
@@ -100,7 +100,7 @@ class FluentExtension extends DataExtension
      * @var string
      * @config
      */
-    private static string $frontend_publish_required = self::INHERITANCE_MODE_FALLBACK;
+    private static string $frontend_publish_required = FluentExtension::INHERITANCE_MODE_FALLBACK;
 
     /**
      * DB fields to be used added in when creating a localised version of the owner's table

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -48,6 +48,7 @@ use TractorCow\Fluent\State\FluentState;
  *
  * @template T of DataObject
  * @extends DataExtension<T&static>
+ * @property DataObject|$this $owner
  */
 class FluentExtension extends DataExtension
 {
@@ -84,6 +85,22 @@ class FluentExtension extends DataExtension
      * current locale, fallback locale, base record
      */
     const INHERITANCE_MODE_ANY = 'any';
+
+    /**
+     * Fluent inheritance mode for CMS context
+     *
+     * @var string
+     * @config
+     */
+    private static string $cms_localisation_required = self::INHERITANCE_MODE_ANY;
+
+    /**
+     * Fluent inheritance mode for frontend context
+     *
+     * @var string
+     * @config
+     */
+    private static string $frontend_publish_required = self::INHERITANCE_MODE_FALLBACK;
 
     /**
      * DB fields to be used added in when creating a localised version of the owner's table

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -48,7 +48,6 @@ use TractorCow\Fluent\State\FluentState;
  *
  * @template T of DataObject
  * @extends DataExtension<T&static>
- * @property DataObject|$this $owner
  */
 class FluentExtension extends DataExtension
 {
@@ -88,17 +87,11 @@ class FluentExtension extends DataExtension
 
     /**
      * Fluent inheritance mode for CMS context
-     *
-     * @var string
-     * @config
      */
     private static string $cms_localisation_required = FluentExtension::INHERITANCE_MODE_ANY;
 
     /**
      * Fluent inheritance mode for frontend context
-     *
-     * @var string
-     * @config
      */
     private static string $frontend_publish_required = FluentExtension::INHERITANCE_MODE_FALLBACK;
 

--- a/src/Extension/FluentFilteredExtension.php
+++ b/src/Extension/FluentFilteredExtension.php
@@ -34,6 +34,14 @@ class FluentFilteredExtension extends DataExtension
      */
     const SUFFIX = 'FilteredLocales';
 
+    /**
+     * Allow the filtered locale behaviour to be skipped for draft stage only
+     *
+     * @var bool
+     * @config
+     */
+    private static bool $apply_filtered_locales_to_stage = false;
+
     private static $many_many = [
         'FilteredLocales' => Locale::class,
     ];

--- a/src/Extension/FluentFilteredExtension.php
+++ b/src/Extension/FluentFilteredExtension.php
@@ -36,11 +36,8 @@ class FluentFilteredExtension extends DataExtension
 
     /**
      * Allow the filtered locale behaviour to be skipped for draft stage only
-     *
-     * @var bool
-     * @config
      */
-    private static bool $apply_filtered_locales_to_stage = false;
+    private static bool $apply_filtered_locales_to_stage = true;
 
     private static $many_many = [
         'FilteredLocales' => Locale::class,

--- a/tests/php/Extension/FluentFilteredExtensionTest.php
+++ b/tests/php/Extension/FluentFilteredExtensionTest.php
@@ -4,11 +4,9 @@ namespace TractorCow\Fluent\Tests\Extension;
 
 use Page;
 use SilverStripe\CMS\Model\SiteTree;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldFilterHeader;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 use TractorCow\Fluent\Extension\FluentFilteredExtension;
 use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
@@ -45,14 +43,14 @@ class FluentFilteredExtensionTest extends SapphireTest
     public function testAugmentSQLFrontend()
     {
         // Specifically set this config value so that filtered locales ARE required in stage=Stage.
-        Config::modify()->set(DataObject::class, 'apply_filtered_locales_to_stage', true);
+        SiteTree::config()->set('apply_filtered_locales_to_stage', true);
 
         $currentStage = Versioned::get_stage();
 
         Versioned::set_stage(Versioned::DRAFT);
 
-        FluentState::singleton()->withState(function (FluentState $newState) {
-            $newState
+        FluentState::singleton()->withState(function (FluentState $state) {
+            $state
                 ->setLocale('en_NZ')
                 ->setIsFrontend(true)
                 ->setIsDomainMode(false);
@@ -73,14 +71,14 @@ class FluentFilteredExtensionTest extends SapphireTest
     public function testAugmentSQLFrontendLive()
     {
         // Specifically set this config value so that filtered locales ARE required in stage=Stage.
-        Config::modify()->set(DataObject::class, 'apply_filtered_locales_to_stage', true);
+        SiteTree::config()->set('apply_filtered_locales_to_stage', true);
 
         $currentStage = Versioned::get_stage();
 
         Versioned::set_stage(Versioned::LIVE);
 
-        FluentState::singleton()->withState(function (FluentState $newState) {
-            $newState
+        FluentState::singleton()->withState(function (FluentState $state) {
+            $state
                 ->setLocale('en_NZ')
                 ->setIsFrontend(true);
 
@@ -100,15 +98,15 @@ class FluentFilteredExtensionTest extends SapphireTest
     public function testAugmentSQLStage()
     {
         // Specifically set this config value so that filtered locales are NOT required in stage=Stage.
-        Config::modify()->set(DataObject::class, 'apply_filtered_locales_to_stage', false);
+        SiteTree::config()->set('apply_filtered_locales_to_stage', false);
 
         $currentStage = Versioned::get_stage();
 
         Versioned::set_stage(Versioned::DRAFT);
 
         // Run test
-        FluentState::singleton()->withState(function (FluentState $newState) {
-            $newState
+        FluentState::singleton()->withState(function (FluentState $state) {
+            $state
                 ->setLocale('en_NZ')
                 ->setIsFrontend(true);
 

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -338,7 +338,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
      * @param bool $frontendContext
      * @param bool $expected
      * @return void
-     * @dataProvider localeInheritanceModeCasesProvider
+     * @dataProvider provideLocaleInheritanceMode
      */
     public function testLocaleInheritanceMode(
         string $cmsInheritanceMode,
@@ -368,56 +368,56 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         });
     }
 
-    public function localeInheritanceModeCasesProvider(): array
+    public function provideLocaleInheritanceMode(): array
     {
         return [
             'cms with any mode, frontend with any mode, frontend context' => [
-                FluentExtension::INHERITANCE_MODE_ANY,
-                FluentExtension::INHERITANCE_MODE_ANY,
-                true,
-                true,
+                'cmsInheritanceMode' => FluentExtension::INHERITANCE_MODE_ANY,
+                'frontendInheritanceMode' => FluentExtension::INHERITANCE_MODE_ANY,
+                'frontendContext' => true,
+                'expected' => true,
             ],
             'cms with exact mode, frontend with any mode, frontend context' => [
-                FluentExtension::INHERITANCE_MODE_EXACT,
-                FluentExtension::INHERITANCE_MODE_ANY,
-                true,
-                true,
+                'cmsInheritanceMode' => FluentExtension::INHERITANCE_MODE_EXACT,
+                'frontendInheritanceMode' => FluentExtension::INHERITANCE_MODE_ANY,
+                'frontendContext' => true,
+                'expected' => true,
             ],
             'cms with exact mode, frontend with exact mode, frontend context' => [
-                FluentExtension::INHERITANCE_MODE_EXACT,
-                FluentExtension::INHERITANCE_MODE_EXACT,
-                true,
-                false,
+                'cmsInheritanceMode' => FluentExtension::INHERITANCE_MODE_EXACT,
+                'frontendInheritanceMode' => FluentExtension::INHERITANCE_MODE_EXACT,
+                'frontendContext' => true,
+                'expected' => false,
             ],
             'cms with any mode, frontend with exact mode, frontend context' => [
-                FluentExtension::INHERITANCE_MODE_ANY,
-                FluentExtension::INHERITANCE_MODE_EXACT,
-                true,
-                false,
+                'cmsInheritanceMode' => FluentExtension::INHERITANCE_MODE_ANY,
+                'frontendInheritanceMode' => FluentExtension::INHERITANCE_MODE_EXACT,
+                'frontendContext' => true,
+                'expected' => false,
             ],
             'cms with any mode, frontend with any mode, cms context' => [
-                FluentExtension::INHERITANCE_MODE_ANY,
-                FluentExtension::INHERITANCE_MODE_ANY,
-                false,
-                true,
+                'cmsInheritanceMode' => FluentExtension::INHERITANCE_MODE_ANY,
+                'frontendInheritanceMode' => FluentExtension::INHERITANCE_MODE_ANY,
+                'frontendContext' => false,
+                'expected' => true,
             ],
             'cms with any mode, frontend with exact mode, cms context' => [
-                FluentExtension::INHERITANCE_MODE_ANY,
-                FluentExtension::INHERITANCE_MODE_EXACT,
-                false,
-                true,
+                'cmsInheritanceMode' => FluentExtension::INHERITANCE_MODE_ANY,
+                'frontendInheritanceMode' => FluentExtension::INHERITANCE_MODE_EXACT,
+                'frontendContext' => false,
+                'expected' => true,
             ],
             'cms with exact mode, frontend with exact mode, cms context' => [
-                FluentExtension::INHERITANCE_MODE_EXACT,
-                FluentExtension::INHERITANCE_MODE_EXACT,
-                false,
-                false,
+                'cmsInheritanceMode' => FluentExtension::INHERITANCE_MODE_EXACT,
+                'frontendInheritanceMode' => FluentExtension::INHERITANCE_MODE_EXACT,
+                'frontendContext' => false,
+                'expected' => false,
             ],
             'cms with exact mode, frontend with any mode, cms context' => [
-                FluentExtension::INHERITANCE_MODE_EXACT,
-                FluentExtension::INHERITANCE_MODE_ANY,
-                false,
-                false,
+                'cmsInheritanceMode' => FluentExtension::INHERITANCE_MODE_EXACT,
+                'frontendInheritanceMode' => FluentExtension::INHERITANCE_MODE_ANY,
+                'frontendContext' => false,
+                'expected' => false,
             ],
         ];
     }

--- a/tests/php/Extension/FluentVersionedExtensionTest.php
+++ b/tests/php/Extension/FluentVersionedExtensionTest.php
@@ -102,7 +102,7 @@ class FluentVersionedExtensionTest extends SapphireTest
                 ->setIsDomainMode(false);
 
             // Read from the locale that the page exists in already
-            /** @var Page $page */
+            /** @var Page|FluentSiteTreeExtension $page */
             $page = $this->objFromFixture(Page::class, 'home');
 
             $this->assertEquals('en_NZ', $page->getSourceLocale()->Locale);


### PR DESCRIPTION
# ENH: Explicit configuration API properties.

## Description

* Added explicit configuration API properties for existing settings
* Minor code refactor for tests (DRY code cleanup)
* No functional changes overall

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
