### PR TITLE
FIX Issues when running with other modules installed

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -1055,6 +1055,14 @@ class FluentExtension extends DataExtension
             $localeObj = Locale::getDefault();
         }
 
+        if (!$locale && !$localeObj) {
+            // There is no default locale, this can happen when if fluent is installed though locales have been setup
+            // This will happen when doing integration unit testing, though can also happen during
+            // regular website operation
+            // This temporary Locale is created to prevent a invalid argument exception in RecordLocale::__construct()
+            $localeObj = Locale::create(['Title' => 'Temp locale']);
+        }
+
         return RecordLocale::create($this->owner, $localeObj);
     }
 

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -3,6 +3,7 @@
 namespace TractorCow\Fluent\Extension;
 
 use LogicException;
+use SilverStripe\i18n\i18n;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
@@ -1055,12 +1056,13 @@ class FluentExtension extends DataExtension
             $localeObj = Locale::getDefault();
         }
 
-        if (!$locale && !$localeObj) {
-            // There is no default locale, this can happen when if fluent is installed though locales have been setup
-            // This will happen when doing integration unit testing, though can also happen during
-            // regular website operation
-            // This temporary Locale is created to prevent a invalid argument exception in RecordLocale::__construct()
-            $localeObj = Locale::create(['Title' => 'Temp locale']);
+        if (!$localeObj) {
+            // There is no default locale, this can happen if no locales have been setup
+            // This will happen when doing integration unit testing, though can also happen during regular
+            // website operation
+            // This temporary Locale is created to prevent a invalid argument exception in
+            // RecordLocale::__construct()
+            $localeObj = Locale::create(['Locale' => i18n::get_locale()]);
         }
 
         return RecordLocale::create($this->owner, $localeObj);

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -1044,8 +1044,11 @@ SQL;
             // Remove existing versions from duplicated object, created by onBeforeWrite
             DB::prepared_query("DELETE FROM \"$versionsTableName\" WHERE \"RecordID\" = ?", [$toID]);
 
+            // Dynamicaly select the current database, which will be a temporary database in case of unit tests
+            $currentDB = DB::query('SELECT DATABASE() as DB')->column('DB')[0];
+
             // Copy all versions of base record, todo: optimize to only copy needed versions
-            $fields = DB::query("SELECT \"COLUMN_NAME\" FROM \"INFORMATION_SCHEMA\".\"COLUMNS\" WHERE \"TABLE_NAME\" = '$versionsTableName' AND \"COLUMN_NAME\" NOT IN('ID','RecordID')");
+            $fields = DB::query("SELECT \"COLUMN_NAME\" FROM \"INFORMATION_SCHEMA\".\"COLUMNS\" WHERE \"TABLE_SCHEMA\" = '$currentDB' AND \"TABLE_NAME\" = '$versionsTableName' AND \"COLUMN_NAME\" NOT IN('ID','RecordID')");
             $fields_str = '"' . implode('","', $fields->column()) . '"';
             DB::prepared_query("INSERT INTO \"$versionsTableName\" ( \"RecordID\", $fields_str)
                     SELECT ? AS \"RecordID\", $fields_str


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/271

There are two separate commits in here fixing different issues, do not squash merge

[FIX Only select columns from the current database](https://github.com/tractorcow-farm/silverstripe-fluent/pull/860/commits/eaece0a7e1c8e3a4492d3d290c84993b52c82b4c) fixes the `Duplicate columns in query` issue

[FIX Create a temp locale if there is not a default](https://github.com/tractorcow-farm/silverstripe-fluent/pull/860/commits/2714bff77c5baebcabf63e5aa281be57f9b05dbf) fixes the `TractorCow\Fluent\Model\RecordLocale::__construct()` issue


