### PR TITLE
ENH Don't use keyword self

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -1023,7 +1023,7 @@ SQL;
             $toID = $this->owner->ID;
 
             // Get localised table
-            $localisedTable = $this->getLocalisedTable($tableName) . self::SUFFIX_VERSIONS;
+            $localisedTable = $this->getLocalisedTable($tableName) . FluentVersionedExtension::SUFFIX_VERSIONS;
 
             // Remove existing translation versions from duplicated object
             DB::prepared_query("DELETE FROM \"$localisedTable\" WHERE \"RecordID\" = ?", [$toID]);
@@ -1039,7 +1039,7 @@ SQL;
                     WHERE \"RecordID\" = ?", [$toID, $fromID]);
 
             // Also copy versions of base record
-            $versionsTableName = $tableName . self::SUFFIX_VERSIONS;
+            $versionsTableName = $tableName . FluentVersionedExtension::SUFFIX_VERSIONS;
 
             // Remove existing versions from duplicated object, created by onBeforeWrite
             DB::prepared_query("DELETE FROM \"$versionsTableName\" WHERE \"RecordID\" = ?", [$toID]);


### PR DESCRIPTION
Fixes https://github.com/tractorcow-farm/silverstripe-fluent/actions/runs/10119372425/job/27987732176

> Can't use keyword 'self'. Use 'FluentVersionedExtension' instead.

See https://github.com/silverstripe/developer-docs/issues/486 and https://github.com/silverstripe/silverstripe-standards/issues/8 for additional context.

## Issue
- https://github.com/silverstripe/.github/issues/287