### PR TITLE
FIX Correct trailing slash for locale in another domain

### DIFF
--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -153,7 +153,10 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
             return;
         }
 
-        // Prefix with domain
+        // Prefix with domain, making sure trailing slash is normalised correctly.
+        if ($link === '/' || $link === '') {
+            $link = Controller::config()->get('add_trailing_slash') ? '/' : '';
+        }
         $link = Controller::join_links($domain->Link(), $link);
     }
 

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -580,8 +580,13 @@ class Locale extends DataObject implements PermissionProvider
 
         if ($append) {
             // Append locale url segment
-            $base = Controller::join_links($base, $this->getURLSegment(), '/');
+            $base = Controller::join_links($base, $this->getURLSegment());
         }
+
+        // Normalise trailing slash
+        // Can't use Controller::normaliseTrailingSlash() because that doesn't
+        // take locale domains into account
+        $base = rtrim($base, '/') . (Controller::config()->get('add_trailing_slash') ? '/' : '');
 
         return $base;
     }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -75,8 +75,8 @@ class FluentSiteTreeExtensionTest extends SapphireTest
             $this->assertEquals('English (New Zealand)', $result->getTitle());
             $this->assertEquals('English', $result->getLanguageNative());
             $this->assertEquals('en', $result->getLanguage());
-            $this->assertEquals(Controller::normaliseTrailingSlash('/newzealand/a-page/'), $result->getLink());
-            $this->assertEquals(Controller::normaliseTrailingSlash('http://mocked/newzealand/a-page/'), $result->getAbsoluteLink());
+            $this->assertEquals($this->normaliseTrailingSlash('/newzealand/a-page/'), $result->getLink());
+            $this->assertEquals($this->normaliseTrailingSlash('http://mocked/newzealand/a-page/'), $result->getAbsoluteLink());
             $this->assertEquals('link', $result->getLinkingMode());
             $this->assertEquals('newzealand', $result->getURLSegment());
         });
@@ -180,7 +180,7 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
                 /** @var Page|FluentSiteTreeExtension $page */
                 $page = $this->objFromFixture(Page::class, $pageName);
-                $this->assertEquals(Controller::normaliseTrailingSlash($url), $page->Link());
+                $this->assertEquals($this->normaliseTrailingSlash($url), $page->Link());
             }
         );
     }
@@ -561,5 +561,18 @@ class FluentSiteTreeExtensionTest extends SapphireTest
                 0,
             ],
         ];
+    }
+
+    /**
+     * Normalises a test URL's trailing slash, but ignores complexities
+     * such as whether the domain host in the UR matches Director::host()
+     */
+    private function normaliseTrailingSlash(string $testURL): string
+    {
+        if ($testURL === '/' || $testURL === '') {
+            return '/';
+        }
+        $slash = Controller::config()->get('add_trailing_slash') ? '/' : '';
+        return (rtrim($testURL, '/')) . $slash;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/tractorcow-farm/silverstripe-fluent/actions/runs/10362465353/job/28684501581 which consists of failures like the below:
> ```text
>  Failed asserting that two strings are equal.
> --- Expected
> +++ Actual
> @@ @@
> -'http://www.example.com/about-us/my-staff/'
> +'http://www.example.com/about-us/my-staff'
> ```

As of silverstripe/framework 5.2.20, `Controller::normaliseTrailingSlash()` won't normalise trailing slash for absolute URLs where the domain doesn't match the current site domain.

This means if getting a link to a page on Locale A from Locale B, if the domains don't match, the trailing slash won't be normalised.

`updateLink()` works in conjunction with `updateRelativeLink()`, so for pages other than the home page the trailing slash is normalised already in `updateRelativeLink()`. But for home pages `updateRelativeLink()` will always resolve to `'/'`, which means before this PR, a trailing slash would _always_ be added for home page links in different locales where domains don't match.

Note that this PR doesn't attempt to resolve this for any other type of data object.

It's possible that it would be better to implement the `updateIsSiteUrl()` extension hook in `FluentDirectorExtension` and saying "yes that's a site URL" if it belongs to a domain of any locale. I didn't attempt that because I don't know what sort of flow-on effects that might have. I'm especially hesitant to do that in a patch release.

@tractorcow do you have any thoughts on this?

## Issue
- https://github.com/silverstripe/.github/issues/290