### PR TITLE
Fix for non RecordLocale Entites when checking Owner Links

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -1068,7 +1068,7 @@ class FluentExtension extends DataExtension
     {
         $locales = [];
         foreach ($this->owner->Locales() as $info) {
-            if ($info->IsDraft()) {
+            if (method_exists($info, 'IsDraft') && $info->IsDraft()) {
                 $locales[] = $info->getLocaleObject();
             }
         }

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -279,7 +279,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
             $info = $owner->LocaleInformation($locale);
 
             // Our content hasn't been drafted or published.
-            if (method_exists($info && 'getSourceLocale') && $info->getSourceLocale()) {
+            if (method_exists($info, 'getSourceLocale') && $info->getSourceLocale()) {
                 // If this Locale has a Fallback, then content might be getting inherited from that Fallback.
                 return _t(
                     __CLASS__ . '.LOCALESTATUSFLUENTINHERITED',

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -279,7 +279,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
             $info = $owner->LocaleInformation($locale);
 
             // Our content hasn't been drafted or published.
-            if ($info->getSourceLocale()) {
+            if (method_exists($info && 'getSourceLocale') && $info->getSourceLocale()) {
                 // If this Locale has a Fallback, then content might be getting inherited from that Fallback.
                 return _t(
                     __CLASS__ . '.LOCALESTATUSFLUENTINHERITED',
@@ -506,7 +506,7 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
         $owner = $this->owner;
         $info = $owner->LocaleInformation($locale);
 
-        if ($info->getSourceLocale()) {
+        if (method_exists($info, 'getSourceLocale') && $info->getSourceLocale()) {
             return;
         }
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
This PR fixes issue on some modules where there are missing methods.  The code was creating a bug such as:

Call to undefined method Purl\Fragment::getSourceLocale()

The bug is likely related to legacy Silverstripe applications, which have since been upgraded to SS 5.

In our context, we use Silverstripe for the Irish Parliament website.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- Not sure how to reproduce this, however it appears to be related to building the site subtree in Silverstripe.  It appears that not all entities which pass through Fluent are `RecordLocale`, and thus a 500 error is thrown on SS.  This was fine when using SS4, but appears to have come after we upgraded to SS5.

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green