### PR TITLE
Merge branch '7' into 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^8.1",
         "silverstripe/vendor-plugin": "^2",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.4",
         "silverstripe/admin": "^2",
         "silverstripe/versioned": "^2",
         "symbiote/silverstripe-gridfieldextensions": "^4",

--- a/src/Task/ConvertTranslatableTask.php
+++ b/src/Task/ConvertTranslatableTask.php
@@ -46,7 +46,7 @@ class ConvertTranslatableTask extends BuildTask
     public function __construct()
     {
         parent::__construct();
-        Deprecation::withSuppressedWarning(function () {
+        Deprecation::withSuppressedNotice(function () {
             Deprecation::notice(
                 '7.3.0',
                 'Will be removed without equivalent functionality to replace it',

--- a/src/Task/ConvertTranslatableTask/Exception.php
+++ b/src/Task/ConvertTranslatableTask/Exception.php
@@ -12,7 +12,7 @@ class Exception extends \Exception
     public function __construct()
     {
         parent::__construct();
-        Deprecation::withSuppressedWarning(function () {
+        Deprecation::withSuppressedNotice(function () {
             Deprecation::notice(
                 '7.3.0',
                 'Will be removed without equivalent functionality to replace it',


### PR DESCRIPTION
Merging up between major versions.
There was a conflict in composer.json that was resolved by rejecting the change.
The change was updating the silverstripe/framework constraint to `^5.4` which is not compatible with `^6` this branch needs.