### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/Model/LocalDateTimeTest.php
+++ b/tests/php/Model/LocalDateTimeTest.php
@@ -88,19 +88,19 @@ class LocalDateTimeTest extends SapphireTest
         return [
             [
                 'locale'    => 'en_NZ',
-                'localTIme' => '2021-01-13 02:00:12',
+                'expectedTime' => '2021-01-13 02:00:12',
             ],
             [
                 'locale'    => 'en_AU',
-                'localTime' => '2021-01-12 23:00:12',
+                'expectedTime' => '2021-01-12 23:00:12',
             ],
             [
                 'locale'    => 'es_ES',
-                'localTime' => '2021-01-12 14:00:12',
+                'expectedTime' => '2021-01-12 14:00:12',
             ],
             [
                 'locale'    => 'es_US',
-                'localTime' => '2021-01-12 08:00:12',
+                'expectedTime' => '2021-01-12 08:00:12',
             ],
         ];
     }

--- a/tests/php/Task/InitialPageLocalisationTaskTest.php
+++ b/tests/php/Task/InitialPageLocalisationTaskTest.php
@@ -11,6 +11,7 @@ use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
 use TractorCow\Fluent\State\FluentState;
 use TractorCow\Fluent\Task\InitialPageLocalisationTask;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Console\Input\InputDefinition;
 
 class InitialPageLocalisationTaskTest extends SapphireTest
 {
@@ -69,17 +70,18 @@ class InitialPageLocalisationTaskTest extends SapphireTest
         $pages = $this->getLocalisedPages();
         $this->assertCount(0, $pages);
 
-        $getParams = [
-            'publish' => $publish,
-            'limit' => $limit,
+        $options = [
+            '--publish' => $publish,
+            '--limit' => $limit,
         ];
 
         // Localise pages
         $task = InitialPageLocalisationTask::singleton();
         $buffer = new BufferedOutput();
         $output = new PolyOutput(PolyOutput::FORMAT_ANSI, wrappedOutput: $buffer);
-        $input = new ArrayInput($getParams);
+        $input = new ArrayInput($options);
         $input->setInteractive(false);
+        $input->bind(new InputDefinition($task->getOptions()));
         $task->run($input, $output);
 
         // Check localised records (should have all pages now)


### PR DESCRIPTION
Fixes https://github.com/tractorcow-farm/silverstripe-fluent/actions/runs/11061583426/job/30734490014

```test
TractorCow\Fluent\Tests\Model\LocalDateTimeTest::testSwitchLocales with data set #0 ('en_NZ', '2021-01-13 02:00:12')
Error: Unknown named parameter $localTIme
```

and

```text
TractorCow\Fluent\Tests\Task\InitialPageLocalisationTaskTest::testInitialPageLocalisation with data set #0 (false, 0, ['Page1', 'Page2', 'Page3', 'Page4'], [])
Symfony\Component\Console\Exception\InvalidArgumentException: The "publish" option does not exist.
```

## Issue
- https://github.com/silverstripe/.github/issues/313