### PR TITLE
skip adding fluent actions menu if it already exists

### DIFF
--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -95,6 +95,11 @@ trait FluentAdminTrait
             return;
         }
 
+        // check if actions menu already exist
+        if ($actions->fieldByName('FluentMenu')) {
+            return;
+        }
+
         // Build root tabset that makes up the menu
         $rootTabSet = TabSet::create('FluentMenu')->setTemplate(
             'FluentAdminTabSet'


### PR DESCRIPTION
## Description

This fixes https://github.com/tractorcow-farm/silverstripe-fluent/issues/888, where in certain situations (e.g. ModelAdmin) the fluent actions menu is added twice, resulting in an error when the form is submitted.

## Manual testing steps

see https://github.com/tractorcow-farm/silverstripe-fluent/issues/888

## Issues

- https://github.com/tractorcow-farm/silverstripe-fluent/issues/888

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
