### PR TITLE
ENH Update status flags generally, not just for SiteTree

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -27,6 +27,7 @@ use SilverStripe\Core\Validation\ValidationException;
 use SilverStripe\Security\Permission;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\HTML;
+use TractorCow\Fluent\Extension\Traits\FluentBadgeTrait;
 use TractorCow\Fluent\Extension\Traits\FluentObjectTrait;
 use TractorCow\Fluent\Forms\CopyLocaleAction;
 use TractorCow\Fluent\Forms\GroupActionMenu;
@@ -1284,6 +1285,114 @@ class FluentExtension extends Extension
         ]);
 
         return $query->firstRow()->execute()->value() !== null;
+    }
+
+    /**
+     * Remove fluent status flags from site tree display
+     */
+    protected function updateStatusFlagsForTreeTitle(array &$flags): void
+    {
+        foreach (array_keys($flags) as $key) {
+            if ($key === 'fluent' || str_starts_with($key, 'fluent ')) {
+                unset($flags[$key]);
+            }
+        }
+    }
+
+    /**
+     * Update status flags based on whether the current record is exists in the current locale.
+     */
+    protected function updateStatusFlags(array &$flags): void
+    {
+        // If there is no current FluentState, then we shouldn't update.
+        if (!FluentState::singleton()->getLocale()) {
+            return;
+        }
+        $this->addLocaleFlags($flags);
+        $this->updateNoSourceFlag($flags);
+    }
+
+    /**
+     * Add a flag based on the record's status in the current locale.
+     */
+    private function addLocaleFlags(array &$flags): void
+    {
+        $locale = Locale::getCurrentLocale();
+        $record = $this->getOwner();
+        $info = RecordLocale::create($record, $locale);
+
+        // Build new badge
+        if ($info->IsDraft()) {
+            // If the object has been localised in the current locale, show a "localised" state
+            $flags['fluent fluent-badge fluent-badge--default'] = [
+                'title' => _t(
+                    FluentBadgeTrait::class . '.BadgeLocalised',
+                    'Localised in {locale}',
+                    [
+                        'locale' => $locale->getTitle()
+                    ]
+                ),
+                'text' => $locale->getLocale(),
+            ];
+        } elseif ($info->getSourceLocale()) {
+            // If object is inheriting content from another locale show the source
+            $flags['fluent fluent-badge fluent-badge--localised'] = [
+                'title' => _t(
+                    FluentBadgeTrait::class . '.BadgeLocalised',
+                    'Localised in {locale}',
+                    [
+                        'locale' => $info->getSourceLocale()->getTitle()
+                    ]
+                ),
+                'text' => $info->getSourceLocale()->getLocale(),
+            ];
+        } else {
+            // Otherwise the object is missing a content source and needs to be remedied
+            // by either localising or seting up a locale fallback
+            $flags['fluent fluent-badge fluent-badge--invisible'] = [
+                'title' => _t(
+                    FluentBadgeTrait::class . '.BaggeInvisible',
+                    '{type} has no available content in {locale}, localise the {type} or provide a locale fallback',
+                    [
+                        'type' => $record->i18n_singular_name(),
+                        'locale' => $locale->getTitle(),
+                    ]
+                ),
+                'text' => $locale->getLocale(),
+            ];
+        }
+    }
+
+    /**
+     * Add a flag which indicates that a record has content in other locale but the content is not being inherited
+     */
+    protected function updateNoSourceFlag(array &$flags): void
+    {
+        if (array_key_exists('archived', $flags)) {
+            return;
+        }
+
+        $locale = FluentState::singleton()->getLocale();
+
+        if (!$locale) {
+            return;
+        }
+
+        $owner = $this->getOwner();
+        $info = $owner->LocaleInformation($locale);
+
+        if ($info->getSourceLocale()) {
+            return;
+        }
+
+        if (!$owner->getLocaleInstances()) {
+            return;
+        }
+
+        $flags['removedfromdraft'] = [
+            'text' => 'No source',
+            'title' => 'This page exists in a different locale but the content is not inherited',
+        ];
     }
 
     /**

--- a/src/Extension/FluentGridFieldExtension.php
+++ b/src/Extension/FluentGridFieldExtension.php
@@ -8,12 +8,10 @@ use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
-use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\Versioned\VersionedGridFieldItemRequest;
 use TractorCow\Fluent\Extension\Traits\FluentAdminTrait;
-use TractorCow\Fluent\Extension\Traits\FluentBadgeTrait;
 
 /**
  * Supports GridFieldDetailForm_ItemRequest with extra actions
@@ -23,19 +21,6 @@ use TractorCow\Fluent\Extension\Traits\FluentBadgeTrait;
 class FluentGridFieldExtension extends Extension
 {
     use FluentAdminTrait;
-    use FluentBadgeTrait;
-
-    /**
-     * Push a badge to indicate the language that owns the current item
-     *
-     * @param DBField|null $badgeField
-     * @see VersionedGridFieldItemRequest::Breadcrumbs()
-     */
-    protected function updateBadge(&$badgeField)
-    {
-        $record = $this->owner->getRecord();
-        $badgeField = $this->addFluentBadge($badgeField, $record);
-    }
 
     protected function updateFormActions(FieldList $actions)
     {

--- a/src/Extension/FluentLeftAndMainExtension.php
+++ b/src/Extension/FluentLeftAndMainExtension.php
@@ -7,11 +7,9 @@ use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\Form;
-use SilverStripe\Model\List\ArrayList;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\View\Requirements;
 use TractorCow\Fluent\Extension\Traits\FluentAdminTrait;
-use TractorCow\Fluent\Extension\Traits\FluentBadgeTrait;
 
 /**
  * @extends Extension<LeftAndMain>
@@ -19,31 +17,11 @@ use TractorCow\Fluent\Extension\Traits\FluentBadgeTrait;
 class FluentLeftAndMainExtension extends Extension
 {
     use FluentAdminTrait;
-    use FluentBadgeTrait;
 
     protected function onInit()
     {
         Requirements::javascript("tractorcow/silverstripe-fluent:client/dist/js/fluent.js");
         Requirements::css("tractorcow/silverstripe-fluent:client/dist/styles/fluent.css");
-    }
-
-    /**
-     * @param ArrayList $breadcrumbs
-     * @see CMSMain::Breadcrumbs()
-     */
-    protected function updateBreadcrumbs(ArrayList $breadcrumbs)
-    {
-        $record = $this->owner->currentPage();
-        if (!$record) {
-            return;
-        }
-
-        // Get a possibly existing badge field from the last item in the breadcrumbs list
-        $lastItem = $breadcrumbs->last();
-        $badgeField = $lastItem->hasField('Extra') ? $lastItem->getField('Extra') : null;
-        $newBadge = $this->addFluentBadge($badgeField, $record);
-
-        $lastItem->setField('Extra', $newBadge);
     }
 
     /**

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -159,33 +159,6 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     }
 
     /**
-     * Check whether the current page is exists in the current locale.
-     *
-     * If it is invisible then we add a class to show it slightly greyed out in the site tree.
-     *
-     * @param array $flags
-     */
-    protected function updateStatusFlags(&$flags)
-    {
-        // If there is no current FluentState, then we shouldn't update.
-        if (!FluentState::singleton()->getLocale()) {
-            return;
-        }
-
-        $this->updateModifiedFlag($flags);
-        $this->updateArchivedFlag($flags);
-        $this->updateNoSourceFlag($flags);
-
-        // If this page does not exist it should be "invisible"
-        if (!$this->isDraftedInLocale() && !$this->isPublishedInLocale()) {
-            $flags['fluentinvisible'] = [
-                'text'  => '',
-                'title' => '',
-            ];
-        }
-    }
-
-    /**
      * @param FieldList $fields
      */
     protected function updateCMSFields(FieldList $fields)
@@ -441,83 +414,6 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
         }
 
         $actions->removeByName('action_restore');
-    }
-
-    /**
-     * Update modified flag to reflect localised record instead of base record
-     * It doesn't make sense to have modified flag if page is not localised in current locale
-     *
-     * @param array $flags
-     */
-    protected function updateModifiedFlag(array &$flags): void
-    {
-        if (!array_key_exists('modified', $flags)) {
-            return;
-        }
-
-        if ($this->owner->isDraftedInLocale()) {
-            return;
-        }
-
-        unset($flags['modified']);
-    }
-
-    /**
-     * Localise archived flag - remove archived flag if there is content on other locales
-     *
-     * @param array $flags
-     */
-    protected function updateArchivedFlag(array &$flags): void
-    {
-        if (!array_key_exists('archived', $flags)) {
-            return;
-        }
-
-        $locale = FluentState::singleton()->getLocale();
-
-        if (!$locale) {
-            return;
-        }
-
-        if (!$this->owner->getLocaleInstances()) {
-            return;
-        }
-
-        unset($flags['archived']);
-    }
-
-    /**
-     * Add a flag which indicates that a page has content in other locale but the content is not being inherited
-     *
-     * @param array $flags
-     */
-    protected function updateNoSourceFlag(array &$flags): void
-    {
-        if (array_key_exists('archived', $flags)) {
-            return;
-        }
-
-        $locale = FluentState::singleton()->getLocale();
-
-        if (!$locale) {
-            return;
-        }
-
-        $owner = $this->owner;
-        $info = $owner->LocaleInformation($locale);
-
-        if ($info->getSourceLocale()) {
-            return;
-        }
-
-        if (!$owner->getLocaleInstances()) {
-            return;
-        }
-
-        $flags['removedfromdraft'] = [
-            'text' => 'No source',
-            'title' => 'This page exists in a different locale but the content is not inherited',
-        ];
     }
 
     /**

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -586,6 +586,76 @@ SQL;
         }
     }
 
+    /**
+     * Check whether the current record is exists in the current locale.
+     *
+     * If it is invisible then we add a class to show it slightly greyed out in the site tree.
+     *
+     * @param array $flags
+     */
+    protected function updateStatusFlags(array &$flags): void
+    {
+        // If there is no current FluentState, then we shouldn't update.
+        if (!FluentState::singleton()->getLocale()) {
+            return;
+        }
+
+        $this->updateModifiedFlag($flags);
+        $this->updateArchivedFlag($flags);
+        parent::updateStatusFlags($flags);
+
+        // If this page does not exist it should be "invisible"
+        if (!$this->isDraftedInLocale() && !$this->isPublishedInLocale()) {
+            $flags['fluentinvisible'] = [
+                'text'  => '',
+                'title' => '',
+            ];
+        }
+    }
+
+    /**
+     * Update modified flag to reflect localised record instead of base record
+     * It doesn't make sense to have modified flag if page is not localised in current locale
+     *
+     * @param array $flags
+     */
+    protected function updateModifiedFlag(array &$flags): void
+    {
+        if (!array_key_exists('modified', $flags)) {
+            return;
+        }
+
+        if ($this->owner->isDraftedInLocale()) {
+            return;
+        }
+
+        unset($flags['modified']);
+    }
+
+    /**
+     * Localise archived flag - remove archived flag if there is content on other locales
+     *
+     * @param array $flags
+     */
+    protected function updateArchivedFlag(array &$flags): void
+    {
+        if (!array_key_exists('archived', $flags)) {
+            return;
+        }
+
+        $locale = FluentState::singleton()->getLocale();
+
+        if (!$locale) {
+            return;
+        }
+
+        if (!$this->owner->getLocaleInstances()) {
+            return;
+        }
+
+        unset($flags['archived']);
+    }
+
     protected function updateLocalisationTabColumns(&$summaryColumns)
     {
         $summaryColumns['Status'] = [

--- a/tests/php/Extension/FluentBadgeExtensionTest.php
+++ b/tests/php/Extension/FluentBadgeExtensionTest.php
@@ -2,84 +2,93 @@
 
 namespace TractorCow\Fluent\Tests\Extension;
 
-use SilverStripe\CMS\Model\SiteTree;
-use SilverStripe\Control\Controller;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\ORM\FieldType\DBHTMLText;
-use TractorCow\Fluent\Extension\FluentLeftAndMainExtension;
-use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
-use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\Extension\FluentExtension;
 use TractorCow\Fluent\State\FluentState;
-use TractorCow\Fluent\Tests\Extension\Stub\FluentStubController;
+use TractorCow\Fluent\Tests\Extension\Stub\FluentDataObject;
 
 class FluentBadgeExtensionTest extends SapphireTest
 {
     protected static $fixture_file = 'FluentBadgeExtensionTest.yml';
 
-    protected static $required_extensions = [
-        SiteTree::class => [
-            FluentSiteTreeExtension::class,
-        ],
+    protected static $extra_dataobjects = [
+        FluentDataObject::class,
     ];
 
-    /**
-     * @var SiteTree
-     */
-    protected $mockPage;
-
-    /**
-     * @var Controller
-     */
-    protected $mockController;
-
-    /**
-     * @var FluentLeftAndMainExtension
-     */
-    protected $extension;
+    protected static $required_extensions = [
+        FluentDataObject::class => [
+            FluentExtension::class,
+        ],
+    ];
 
     protected function setUp(): void
     {
         parent::setUp();
-
-        // Clear cache
-        Locale::clearCached();
-
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState->setLocale('en_NZ');
-
-            $this->mockPage = $this->objFromFixture(SiteTree::class, 'test_page');
-            $this->mockController = new FluentStubController($this->mockPage->ID);
-            $this->extension = new FluentLeftAndMainExtension();
-            $this->extension->setOwner($this->mockController);
+            $record = $this->objFromFixture(FluentDataObject::class, 'test_record');
+            // Ensure the record is written in this locale
+            $record->write();
         });
     }
 
+    /**
+     * Tests status flag added for the locale this is saved in
+     */
     public function testDefaultLocaleBadgeAdded()
     {
         // Publish the page in the default locale
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState->setLocale('en_NZ');
-            $this->mockPage->publishRecursive();
+            $record = $this->objFromFixture(FluentDataObject::class, 'test_record');
+            $flags = $record->getStatusFlags();
 
-            $result = $this->extension->getBadge($this->mockPage);
-            $this->assertInstanceOf(DBHTMLText::class, $result);
-            $this->assertStringContainsString('fluent-badge--default', $result->getValue());
-            $this->assertStringContainsString('Localised in', $result->getValue());
-            $this->assertStringContainsString('NZ', $result->getValue(), 'Badge shows owner locale');
+            $this->assertArrayHasKey('fluent fluent-badge fluent-badge--default', $flags);
+            $this->assertSame(
+                ['title' => 'Localised in English (NZ)', 'text' => 'en_NZ'],
+                $flags['fluent fluent-badge fluent-badge--default']
+            );
         });
     }
 
+    /**
+     * Tests status flag added for the fallback locale
+     */
+    public function testLocalisedLocaleBadgeAdded()
+    {
+        // Publish the page in the default locale
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState->setLocale('pt_PT');
+            $record = $this->objFromFixture(FluentDataObject::class, 'test_record');
+            $flags = $record->getStatusFlags();
+
+            $this->assertArrayHasKey('fluent fluent-badge fluent-badge--localised', $flags);
+            $this->assertSame(
+                ['title' => 'Localised in English (NZ)', 'text' => 'en_NZ'],
+                $flags['fluent fluent-badge fluent-badge--localised']
+            );
+        });
+    }
+
+    /**
+     * Tests status flag added to indicate this record is NOT saved in this locale
+     */
     public function testInvisibleLocaleBadgeWasAdded()
     {
         FluentState::singleton()->withState(function (FluentState $newState) {
             // Don't write the page in the non-default locale, then it shouldn't exist
             $newState->setLocale('de_DE');
+            $record = $this->objFromFixture(FluentDataObject::class, 'test_record');
+            $flags = $record->getStatusFlags();
 
-            $result = $this->extension->getBadge($this->mockPage);
-            $this->assertInstanceOf(DBHTMLText::class, $result);
-            $this->assertStringContainsString('fluent-badge--invisible', $result->getValue());
-            $this->assertStringContainsString('Page has no available content in', $result->getValue());
-            $this->assertStringContainsString('de_DE', $result->getValue(), 'Badge shows owner locale');
+            $this->assertArrayHasKey('fluent fluent-badge fluent-badge--invisible', $flags);
+            $this->assertSame(
+                [
+                    'title' => 'Fluent Data Object has no available content in German, localise the Fluent Data Object or provide a locale fallback',
+                    'text' => 'de_DE',
+                ],
+                $flags['fluent fluent-badge fluent-badge--invisible']
+            );
         });
     }
 }

--- a/tests/php/Extension/FluentBadgeExtensionTest.yml
+++ b/tests/php/Extension/FluentBadgeExtensionTest.yml
@@ -8,9 +8,17 @@ TractorCow\Fluent\Model\Locale:
     Title: German
     Locale: de_DE
     URLSegment: de_DE
+  pt_PT:
+    Title: Portuguese
+    Locale: pt_PT
+    URLSegment: pt_PT
 
-SilverStripe\CMS\Model\SiteTree:
-  test_page:
+TractorCow\Fluent\Model\FallbackLocale:
+  en_NZ:
+    Locale: =>TractorCow\Fluent\Model\Locale.en_NZ
+    Parent: =>TractorCow\Fluent\Model\Locale.pt_PT
+
+TractorCow\Fluent\Tests\Extension\Stub\FluentDataObject:
+  test_record:
     Title: Test page
-    URLSegment: test-page
-    Content: Test content
+    Description: Test content


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-framework/pull/11460 makes the `updateStatusFlags()` extension hook available for all models. In combination with other PRs linked in the below issue, status flag rendering has now been standardised.

This PR updates fluent to add fluent status flags to any fluent model, not just `SiteTree`, and removes custom code that renders flags in places like `LeftAndMain` breadcrumbs, gridfield edit form breadcrumbs, and gridfield rows. Those are all handled in core now.

Please note that this PR relies on https://github.com/silverstripe/silverstripe-framework/pull/11460 along with others.
**_Please do not merge this PR until all dependent PRs have been merged._**

Looks like this in CMSMain:
![Screenshot from 2024-11-20 14-56-20](https://github.com/user-attachments/assets/6dc4bdcf-d1f9-45ff-93a3-944601f42dd7)

Looks like this in gridfield (yes that is a gridfield holding pages, no it is not CMSMain):
![image](https://github.com/user-attachments/assets/fcd7babe-a9a3-458c-9336-82de46bd520e)
![image](https://github.com/user-attachments/assets/ef3ace59-064d-400a-a3eb-ded8f63e16b7)

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947