### PR TITLE
ENH: Localisation manager filter.

### DIFF
--- a/src/Extension/Traits/FluentObjectTrait.php
+++ b/src/Extension/Traits/FluentObjectTrait.php
@@ -161,7 +161,6 @@ trait FluentObjectTrait
             $this->LinkedLocales(),
             $config
         );
-
         if ($fields->hasTabSet()) {
             $fields->addFieldToTab('Root.Locales', $gridField);
 

--- a/src/Extension/Traits/FluentObjectTrait.php
+++ b/src/Extension/Traits/FluentObjectTrait.php
@@ -16,7 +16,9 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\Filters\PartialMatchFilter;
 use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\ORM\Search\BasicSearchContext;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
 
@@ -107,9 +109,8 @@ trait FluentObjectTrait
 
         // Generate gridfield for handling localisations
         $config = GridFieldConfig_Base::create();
-        // Remove filters as the displayed data is in ArrayList format
-        $config->removeComponentsByType(GridFieldFilterHeader::class);
 
+        /** @var GridFieldDataColumns $columns */
         $columns = $config->getComponentByType(GridFieldDataColumns::class);
         $summaryColumns = [
             'Title' => 'Title',
@@ -163,6 +164,38 @@ trait FluentObjectTrait
             $this->LinkedLocales(),
             $config
         );
+
+        /** @var GridFieldFilterHeader $filterHeader */
+        $filterHeader = $config->getComponentByType(GridFieldFilterHeader::class);
+
+        // Replace scaffolded filters as the displayed data is in ArrayList format so scaffolded filters do not work
+        if ($filterHeader) {
+            // Retrieve filters settings as these can be carried over as is
+            $defaultSearchContext = $filterHeader->getSearchContext($gridField);
+            $defaultSearchFields = $defaultSearchContext->getSearchFields();
+            $defaultFilters = $defaultSearchContext->getFilters();
+
+            /** @var ArrayList $list */
+            $list = $gridField->getList();
+
+            // Carry over any search form settings
+            $searchContext = BasicSearchContext::create($list->dataClass());
+            $searchContext->setFields($defaultSearchFields);
+
+            // Carry over filter configuration (make changes to filter classes so they work with ArrayList data)
+            foreach ($defaultFilters as $defaultFilter) {
+                $fieldFilter = PartialMatchFilter::create(
+                    // Use name instead of full name as this plain filter doesn't understand relations
+                    $defaultFilter->getName(),
+                    $defaultFilter->getValue(),
+                    $defaultFilter->getModifiers(),
+                );
+                $searchContext->addFilter($fieldFilter);
+            }
+
+            $filterHeader->setSearchContext($searchContext);
+        }
+
         if ($fields->hasTabSet()) {
             $fields->addFieldToTab('Root.Locales', $gridField);
 

--- a/src/Extension/Traits/FluentObjectTrait.php
+++ b/src/Extension/Traits/FluentObjectTrait.php
@@ -16,9 +16,7 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\ORM\Filters\PartialMatchFilter;
 use SilverStripe\ORM\Queries\SQLSelect;
-use SilverStripe\ORM\Search\BasicSearchContext;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
 
@@ -110,7 +108,6 @@ trait FluentObjectTrait
         // Generate gridfield for handling localisations
         $config = GridFieldConfig_Base::create();
 
-        /** @var GridFieldDataColumns $columns */
         $columns = $config->getComponentByType(GridFieldDataColumns::class);
         $summaryColumns = [
             'Title' => 'Title',
@@ -164,37 +161,6 @@ trait FluentObjectTrait
             $this->LinkedLocales(),
             $config
         );
-
-        /** @var GridFieldFilterHeader $filterHeader */
-        $filterHeader = $config->getComponentByType(GridFieldFilterHeader::class);
-
-        // Replace scaffolded filters as the displayed data is in ArrayList format so scaffolded filters do not work
-        if ($filterHeader) {
-            // Retrieve filters settings as these can be carried over as is
-            $defaultSearchContext = $filterHeader->getSearchContext($gridField);
-            $defaultSearchFields = $defaultSearchContext->getSearchFields();
-            $defaultFilters = $defaultSearchContext->getFilters();
-
-            /** @var ArrayList $list */
-            $list = $gridField->getList();
-
-            // Carry over any search form settings
-            $searchContext = BasicSearchContext::create($list->dataClass());
-            $searchContext->setFields($defaultSearchFields);
-
-            // Carry over filter configuration (make changes to filter classes so they work with ArrayList data)
-            foreach ($defaultFilters as $defaultFilter) {
-                $fieldFilter = PartialMatchFilter::create(
-                    // Use name instead of full name as this plain filter doesn't understand relations
-                    $defaultFilter->getName(),
-                    $defaultFilter->getValue(),
-                    $defaultFilter->getModifiers(),
-                );
-                $searchContext->addFilter($fieldFilter);
-            }
-
-            $filterHeader->setSearchContext($searchContext);
-        }
 
         if ($fields->hasTabSet()) {
             $fields->addFieldToTab('Root.Locales', $gridField);

--- a/tests/php/Extension/FluentFilteredExtensionTest.php
+++ b/tests/php/Extension/FluentFilteredExtensionTest.php
@@ -152,7 +152,10 @@ class FluentFilteredExtensionTest extends SapphireTest
                 LocaleToggleColumn::class,
                 $config->getComponentByType(LocaleToggleColumn::class)
             );
-            $this->assertNull($config->getComponentByType(GridFieldFilterHeader::class));
+            $this->assertInstanceOf(
+                GridFieldFilterHeader::class,
+                $config->getComponentByType(GridFieldFilterHeader::class)
+            );
         });
     }
 


### PR DESCRIPTION
## Description

Enables filtering capability in the localisation manager. This filter wasn't present because pre CMS 5 such feature was not supported. With CMS 5 it's possible so we should enable it.

![Screenshot 2025-01-22 at 12 51 51 PM](https://github.com/user-attachments/assets/696e2b9b-7368-4d84-905e-916c18a75806)

## Manual testing steps

* Navigate to the localisation manager on any localised model and confirm that the filter is working from scaffolded fields

## Issues

https://github.com/tractorcow-farm/silverstripe-fluent/issues/924

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
