### PR TITLE
FIX Correctly set duplicated has_one records for localised records

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -24,6 +24,7 @@ use SilverStripe\ORM\FieldType\DBText;
 use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\ORM\Queries\SQLConditionGroup;
 use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\ORM\Queries\SQLUpdate;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Security\Permission;
 use SilverStripe\Versioned\Versioned;
@@ -636,7 +637,18 @@ class FluentExtension extends DataExtension
      */
     public function onAfterDuplicate($original, $doWrite, $relations): void
     {
+        $owner = $this->getOwner();
         $localisedTables = $this->owner->getLocalisedTables();
+        // Get the names of all has_one columns that will have new IDs
+        $copyRelations = (array) $owner->config()->get('localised_copy');
+        $hasOne = $owner->hasOne();
+        $copyHasOneRelations = [];
+        foreach ($copyRelations as $relationName) {
+            if (array_key_exists($relationName, $hasOne)) {
+                $copyHasOneRelations[] = $relationName . 'ID';
+            }
+        }
+        // Add row for new duplicated page in all relevant localised tables
         foreach ($localisedTables as $tableName => $fields) {
             // Target IDs
             $fromID = $original->ID;
@@ -654,6 +666,18 @@ class FluentExtension extends DataExtension
                     SELECT ? AS \"RecordID\", \"Locale\", $fields_str
                     FROM \"$localisedTable\"
                     WHERE \"RecordID\" = ?", [$toID, $fromID]);
+
+            // Make sure to update any has_one IDs - otherwise the new localised table entry will
+            // have the has_one ID from the original record.
+            // The current $owner (i.e. the newly duplicated record) may have already had its relation duplicated
+            // via cascade_duplicates prior to this extension hook being called.
+            $fieldsToUpdate = [];
+            foreach (array_intersect($fields, $copyHasOneRelations) as $copyFieldName) {
+                $fieldsToUpdate[$copyFieldName] = $owner->{$copyFieldName};
+            }
+            if (!empty($fieldsToUpdate)) {
+                SQLUpdate::create($localisedTable, $fieldsToUpdate, ['RecordID' => $toID])->execute();
+            }
         }
     }
 

--- a/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
+++ b/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
@@ -238,6 +238,40 @@ class DuplicationTest extends SapphireTest
         });
     }
 
+    /**
+     * case: duplicate() called on localised record
+     * desired outcome: has_one duplication is copied correctly to localised table
+     */
+    public function testDuplicate(): void
+    {
+        FluentState::singleton()->withState(function (FluentState $state): void {
+            $state->setLocale('en_NZ');
+
+            /** @var Horse|FluentExtension $originalHorse */
+            $originalHorse = $this->objFromFixture(Horse::class, 'horse1');
+            $tail = $originalHorse->Tail();
+            $originalTailID = $tail->ID;
+            $horseCountBefore = Horse::get()->count();
+            $tailsCountBefore = Tail::get()->count();
+
+            // Duplicate the horse (and its tail by association)
+            $duplicateHorse = $originalHorse->duplicate();
+
+            $horseCountAfter = Horse::get()->count();
+            $tailsCountAfter = Tail::get()->count();
+            $this->assertEquals($horseCountBefore + 1, $horseCountAfter);
+            $this->assertEquals($tailsCountBefore + 1, $tailsCountAfter);
+
+            // Re-fetch both horses so we are asserting on what's in the DB not just what's in memory
+            $originalHorse = Horse::get()->byID($originalHorse->ID);
+            $duplicateHorse = Horse::get()->byID($duplicateHorse->ID);
+
+            $this->assertNotSame($originalHorse->ID, $duplicateHorse->ID);
+            $this->assertNotSame($originalHorse->TailID, $duplicateHorse->TailID);
+            $this->assertSame($originalTailID, $originalHorse->TailID);
+        });
+    }
+
     public function localesProvider(): array
     {
         return [


### PR DESCRIPTION

## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
When duplicating a localised parent record, any `has_one` relations that should be localised with it still have the child ID of the original parent record. This means any changes to the duplicate child also apply to the original child because they're the same record.

The following configuration all needs to be set on the parent record, listing the child has_one relation in all of them
- `field_include`
- `localised_copy`
- `cascade_duplicates`

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

1. Create a record with a `has_one` relation and localise that relation. I used elemental applied to a page, but the below config applied to the parent class should work:
    ```php
    private static array $has_one = [
        'MyRelation' => MyDataObject::class,
    ];

    private static array $field_include = [
        'MyRelationID',
    ];
    
    private static array $localised_copy = [
        'MyRelation',
    ];
    
    private static array $cascade_duplicates = [
        'MyRelation',
    ];

    private static array $extensions = [
        FluentExtension::class,
    ];
    ```
1. Create a locale in the CMS through `admin/locales`
1. Make sure you swap to the new locale in the CMS
1. Create the parent record in the CMS
1. Add a child record in the CMS
1. Duplicate the parent record.

Without this PR, the child attached to the new duplicate record is the _same_ as the one attached to the original, even though it should be a new one.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/tractorcow-farm/silverstripe-fluent/issues/931

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
