### PR TITLE
FIX Allow new query parameters for fluent versioned queries

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -185,6 +185,8 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
                 break;
             // Return all version instances
             case 'archive':
+            case 'archive_only':
+            case 'removed_from_draft':
             case 'all_versions':
             case 'latest_versions':
             case 'latest_version_single':


### PR DESCRIPTION
Bug found while smoke testing CMS 6.0.0-beta1 deployment to SC AWS - with a localised archived page, visiting `/admin/archive` gives the following error:

```text
Uncaught InvalidArgumentException: Bad value for query parameter Versioned.mode: removed_from_draft
GET /admin/archive

Line 196 in /var/www/html/vendor/tractorcow/silverstripe-fluent/src/Extension/FluentVersionedExtension.php
```

## Issue
- https://github.com/silverstripeltd/product-issues/issues/894