### PR TITLE
FIX Multi locale localised copy correction.

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -698,32 +698,10 @@ class FluentExtension extends DataExtension
             return;
         }
 
-        $locales = [];
+        $locales = $this->getLocaleCodesFormModel($owner);
 
-        /** @var RecordLocale $localeInformation */
-        foreach ($owner->Locales() as $localeInformation) {
-            $sourceLocale = $localeInformation->getSourceLocale();
-            $modelLocale = $localeInformation->getLocaleObject();
-
-            if (!$sourceLocale) {
-                // We don't have any source locale, so we can bail out
-                continue;
-            }
-
-            if ($modelLocale->Locale !== $sourceLocale->Locale) {
-                // Source of this locale is different from current locale, so we can skip it
-                // as this locale content is being inherited
-                continue;
-            }
-
-            if ($modelLocale->Locale === $currentLocale) {
-                // Current locale can be skipped as it was already handled correctly
-                continue;
-            }
-
-            // Add locale which uses current locale as a source to our list
-            $locales[] = $modelLocale->Locale;
-        }
+        // Current locale can be skipped as it was already handled correctly
+        $locales = array_diff($locales, [$currentLocale]);
 
         // No locales need to be actioned
         if (count($locales) === 0) {
@@ -1603,5 +1581,39 @@ class FluentExtension extends DataExtension
 
         // all other cases should not duplicate (normal edits)
         return false;
+    }
+
+    /**
+     * Get a list of locale codes that represent locales that the model is localised in
+     * TODO make this method public and use $owner instead as this is a useful utility method
+     *
+     * @param DataObject $model
+     * @return array
+     */
+    private function getLocaleCodesFormModel(DataObject $model): array
+    {
+        $locales = [];
+
+        /** @var RecordLocale $localeInformation */
+        foreach ($model->Locales() as $localeInformation) {
+            $sourceLocale = $localeInformation->getSourceLocale();
+            $modelLocale = $localeInformation->getLocaleObject();
+
+            if (!$sourceLocale) {
+                // We don't have any source locale, so we can bail out
+                continue;
+            }
+
+            if ($modelLocale->Locale !== $sourceLocale->Locale) {
+                // Source of this locale is different from current locale, so we can skip it
+                // as this locale content is being inherited
+                continue;
+            }
+
+            // Add locale which uses current locale as a source to our list
+            $locales[] = $modelLocale->Locale;
+        }
+
+        return $locales;
     }
 }

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -712,19 +712,20 @@ class FluentExtension extends DataExtension
 
         foreach ($locales as $locale) {
             FluentState::singleton()->withState(
-                static function (FluentState $state) use ($owner, $ownerVersioned, $locale, $copyRelations): void {
+                static function (FluentState $state) use ($owner, $original, $ownerVersioned, $locale, $copyRelations): void {
                     $state->setLocale($locale);
 
                     $localisedOwner = DataObject::get($owner->ClassName)->byID($owner->ID);
+                    $localisedOriginal = DataObject::get($original->ClassName)->byID($original->ID);
 
                     // Couldn't find localised data to work with
-                    if (!$localisedOwner) {
+                    if (!$localisedOwner || !$localisedOriginal) {
                         return;
                     }
 
                     // Duplicate all localised relations
                     foreach ($copyRelations as $relation) {
-                        $originalRelation = $localisedOwner->getComponent($relation);
+                        $originalRelation = $localisedOriginal->getComponent($relation);
 
                         if (!$originalRelation instanceof DataObject) {
                             continue;

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -642,12 +642,15 @@ class FluentExtension extends DataExtension
 
         // Get the names of all has_one columns that will have new IDs
         $copyRelations = (array) $owner->config()->get('localised_copy');
+        $cascadeDuplicates = (array) $owner->config()->get('cascade_duplicates');
         $hasOne = $owner->hasOne();
         $copyHasOneRelations = [];
 
         foreach ($copyRelations as $relationName) {
-            if (array_key_exists($relationName, $hasOne)) {
-                $copyHasOneRelations[] = $relationName . 'ID';
+            // We only need to process has_one relations which are covered in both localised_copy & cascade_duplicates
+            // because only such cases need special handling for duplication
+            if (array_key_exists($relationName, $hasOne) && in_array($relationName, $cascadeDuplicates)) {
+                $copyHasOneRelations[$relationName] = $relationName . 'ID';
             }
         }
 
@@ -708,14 +711,17 @@ class FluentExtension extends DataExtension
             return;
         }
 
-        $ownerVersioned = $owner->hasExtension(Versioned::class);
+        $ownerIsVersioned = $owner->hasExtension(Versioned::class);
 
         foreach ($locales as $locale) {
             FluentState::singleton()->withState(
-                static function (FluentState $state) use ($owner, $original, $ownerVersioned, $locale, $copyRelations): void {
+                static function (FluentState $state) use ($owner, $original, $ownerIsVersioned, $locale, $copyRelations): void {
                     $state->setLocale($locale);
 
+                    // This is model which was created by the duplication
                     $localisedOwner = DataObject::get($owner->ClassName)->byID($owner->ID);
+
+                    // This is the model that we were duplicating
                     $localisedOriginal = DataObject::get($original->ClassName)->byID($original->ID);
 
                     // Couldn't find localised data to work with
@@ -724,13 +730,9 @@ class FluentExtension extends DataExtension
                     }
 
                     // Duplicate all localised relations
-                    foreach ($copyRelations as $relation) {
+                    foreach ($copyRelations as $relation => $relationIDField) {
                         $localisedRelation = $localisedOwner->getComponent($relation);
                         $originalRelation = $localisedOriginal->getComponent($relation);
-
-                        if (!$originalRelation instanceof DataObject) {
-                            continue;
-                        }
 
                         if (!$originalRelation->isInDB()) {
                             continue;
@@ -751,17 +753,17 @@ class FluentExtension extends DataExtension
                                 }
                             );
                         } else {
-                            $duplicate = $originalRelation->duplicate();
+                            $duplicate = $originalRelation->duplicate(false);
                         }
 
                         $localisedOwner->setComponent($relation, $duplicate);
                     }
 
                     // Update localised data (without version as this is considered a part of the duplication action)
-                    $localisedOwner->withLocalisedCopyState(function () use ($ownerVersioned, $localisedOwner): void {
+                    $localisedOwner->withLocalisedCopyState(function () use ($ownerIsVersioned, $localisedOwner): void {
                         // Prevent unintended interactions with localised copy feature
                         $localisedOwner->setLocalisedCopyActive(false);
-                        $ownerVersioned
+                        $ownerIsVersioned
                             ? $localisedOwner->writeWithoutVersion()
                             : $localisedOwner->write();
                     });
@@ -1602,13 +1604,6 @@ class FluentExtension extends DataExtension
         return false;
     }
 
-    /**
-     * Get a list of locale codes that represent locales that the model is localised in
-     * TODO make this method public and use $owner instead as this is a useful utility method
-     *
-     * @param DataObject $model
-     * @return array
-     */
     private function getLocaleCodesForModel(DataObject $model): array
     {
         $locales = [];

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -638,21 +638,26 @@ class FluentExtension extends DataExtension
     public function onAfterDuplicate($original, $doWrite, $relations): void
     {
         $owner = $this->getOwner();
-        $localisedTables = $this->owner->getLocalisedTables();
+        $localisedTables = $owner->getLocalisedTables();
+
         // Get the names of all has_one columns that will have new IDs
         $copyRelations = (array) $owner->config()->get('localised_copy');
         $hasOne = $owner->hasOne();
         $copyHasOneRelations = [];
+
         foreach ($copyRelations as $relationName) {
-            if (array_key_exists($relationName, $hasOne)) {
-                $copyHasOneRelations[] = $relationName . 'ID';
+            if (!array_key_exists($relationName, $hasOne)) {
+                continue;
             }
+
+            $copyHasOneRelations[] = $relationName . 'ID';
         }
+
         // Add row for new duplicated page in all relevant localised tables
         foreach ($localisedTables as $tableName => $fields) {
             // Target IDs
             $fromID = $original->ID;
-            $toID = $this->owner->ID;
+            $toID = $owner->ID;
 
             // Get localised table
             $localisedTable = $this->getLocalisedTable($tableName);
@@ -671,6 +676,7 @@ class FluentExtension extends DataExtension
             // have the has_one ID from the original record.
             // The current $owner (i.e. the newly duplicated record) may have already had its relation duplicated
             // via cascade_duplicates prior to this extension hook being called.
+            // This only covers the current locale though
             $fieldsToUpdate = [];
             foreach (array_intersect($fields, $copyHasOneRelations) as $copyFieldName) {
                 $fieldsToUpdate[$copyFieldName] = $owner->{$copyFieldName};
@@ -678,6 +684,86 @@ class FluentExtension extends DataExtension
             if (!empty($fieldsToUpdate)) {
                 SQLUpdate::create($localisedTable, $fieldsToUpdate, ['RecordID' => $toID])->execute();
             }
+        }
+
+        // We don't have any localised relations to cover
+        if (count($copyHasOneRelations) === 0) {
+            return;
+        }
+
+        $currentLocale = FluentState::singleton()->getLocale();
+
+        // We don't have a current locale which indicates that the Fluent setup is incomplete - bail out
+        if (!$currentLocale) {
+            return;
+        }
+
+        $locales = [];
+
+        /** @var RecordLocale $localeInformation */
+        foreach ($owner->Locales() as $localeInformation) {
+            $sourceLocale = $localeInformation->getSourceLocale();
+            $modelLocale = $localeInformation->getLocaleObject();
+
+            if (!$sourceLocale) {
+                // We don't have any source locale, so we can bail out
+                continue;
+            }
+
+            if ($modelLocale->Locale !== $sourceLocale->Locale) {
+                // Source of this locale is different from current locale, so we can skip it
+                // as this locale content is being inherited
+                continue;
+            }
+
+            if ($modelLocale->Locale === $currentLocale) {
+                // Current locale can be skipped as it was already handled correctly
+                continue;
+            }
+
+            // Add locale which uses current locale as a source to our list
+            $locales[] = $modelLocale->Locale;
+        }
+
+        // No locales need to be actioned
+        if (count($locales) === 0) {
+            return;
+        }
+
+        foreach ($locales as $locale) {
+            FluentState::singleton()->withState(
+                static function (FluentState $state) use ($owner, $locale, $copyRelations): void {
+                    $state->setLocale($locale);
+
+                    $localisedOwner = DataObject::get($owner->ClassName)->byID($owner->ID);
+
+                    // Couldn't find localised to to work with
+                    if (!$localisedOwner->exists()) {
+                        return;
+                    }
+
+                    // Duplicate all localised relations
+                    foreach ($copyRelations as $relation) {
+                        $original = $localisedOwner->{$relation}();
+
+                        if (!$original instanceof DataObject) {
+                            continue;
+                        }
+
+                        if (!$original->exists()) {
+                            continue;
+                        }
+
+                        $duplicate = $original->duplicate();
+                        $localisedOwner->setComponent($relation, $duplicate);
+                    }
+
+                    // Update localised data (without version as this is considered a part of the duplication action)
+                    $localisedOwner->hasExtension(Versioned::class)
+                        ? $localisedOwner->writeWithoutVersion()
+                        : $localisedOwner->write();
+                }
+            );
         }
     }
 

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -715,7 +715,7 @@ class FluentExtension extends DataExtension
 
         foreach ($locales as $locale) {
             FluentState::singleton()->withState(
-                static function (FluentState $state) use ($owner, $original, $ownerIsVersioned, $locale, $copyRelations): void {
+                static function (FluentState $state) use ($owner, $original, $ownerIsVersioned, $locale, $copyHasOneRelations): void {
                     $state->setLocale($locale);
 
                     // This is model which was created by the duplication
@@ -730,7 +730,7 @@ class FluentExtension extends DataExtension
                     }
 
                     // Duplicate all localised relations
-                    foreach ($copyRelations as $relation => $relationIDField) {
+                    foreach ($copyHasOneRelations as $relation => $relationIDField) {
                         $localisedRelation = $localisedOwner->getComponent($relation);
                         $originalRelation = $localisedOriginal->getComponent($relation);
 
@@ -744,7 +744,7 @@ class FluentExtension extends DataExtension
                             : 0;
 
                         // Elemental module compatibility
-                        if ($topPageID && $originalRelation->hasMethod('withFixedTopPage')) {
+                        if ($topPageID && $originalRelation->hasExtension(\DNADesign\Elemental\TopPage\DataExtension::class)) {
                             $duplicate = $originalRelation->withFixedTopPage(
                                 $topPageID,
                                 static function () use ($originalRelation): DataObject {

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -642,14 +642,13 @@ class FluentExtension extends DataExtension
 
         // Get the names of all has_one columns that will have new IDs
         $copyRelations = (array) $owner->config()->get('localised_copy');
-        $cascadeDuplicates = (array) $owner->config()->get('cascade_duplicates');
         $hasOne = $owner->hasOne();
         $copyHasOneRelations = [];
 
         foreach ($copyRelations as $relationName) {
-            // We only need to process has_one relations which are covered in both localised_copy & cascade_duplicates
+            // We only need to process has_one relations which are covered in localised_copy and are part of this duplication
             // because only such cases need special handling for duplication
-            if (array_key_exists($relationName, $hasOne) && in_array($relationName, $cascadeDuplicates)) {
+            if (array_key_exists($relationName, $hasOne) && in_array($relationName, $relations)) {
                 $copyHasOneRelations[$relationName] = $relationName . 'ID';
             }
         }
@@ -718,16 +717,11 @@ class FluentExtension extends DataExtension
                 static function (FluentState $state) use ($owner, $original, $ownerIsVersioned, $locale, $copyHasOneRelations): void {
                     $state->setLocale($locale);
 
-                    // This is model which was created by the duplication
+                    // This is localised copy of the record which was created by the duplication
                     $localisedOwner = DataObject::get($owner->ClassName)->byID($owner->ID);
 
-                    // This is the model that we were duplicating
+                    // This is the localised copy of the original record that we were duplicating
                     $localisedOriginal = DataObject::get($original->ClassName)->byID($original->ID);
-
-                    // Couldn't find localised data to work with
-                    if (!$localisedOwner || !$localisedOriginal) {
-                        return;
-                    }
 
                     // Duplicate all localised relations
                     foreach ($copyHasOneRelations as $relation => $relationIDField) {

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -646,11 +646,9 @@ class FluentExtension extends DataExtension
         $copyHasOneRelations = [];
 
         foreach ($copyRelations as $relationName) {
-            if (!array_key_exists($relationName, $hasOne)) {
-                continue;
+            if (array_key_exists($relationName, $hasOne)) {
+                $copyHasOneRelations[] = $relationName . 'ID';
             }
-
-            $copyHasOneRelations[] = $relationName . 'ID';
         }
 
         // Add row for new duplicated page in all relevant localised tables
@@ -676,7 +674,7 @@ class FluentExtension extends DataExtension
             // have the has_one ID from the original record.
             // The current $owner (i.e. the newly duplicated record) may have already had its relation duplicated
             // via cascade_duplicates prior to this extension hook being called.
-            // This only covers the current locale though
+            // This only covers the current locale - see below for handling additional locales.
             $fieldsToUpdate = [];
             foreach (array_intersect($fields, $copyHasOneRelations) as $copyFieldName) {
                 $fieldsToUpdate[$copyFieldName] = $owner->{$copyFieldName};
@@ -685,6 +683,8 @@ class FluentExtension extends DataExtension
                 SQLUpdate::create($localisedTable, $fieldsToUpdate, ['RecordID' => $toID])->execute();
             }
         }
+
+        // We need to handle duplicating relations in `localised_copy` into additional locales
 
         // We don't have any localised relations to cover
         if (count($copyHasOneRelations) === 0) {
@@ -730,38 +730,44 @@ class FluentExtension extends DataExtension
             return;
         }
 
+        $ownerVersioned = $owner->hasExtension(Versioned::class);
+
         foreach ($locales as $locale) {
             FluentState::singleton()->withState(
-                static function (FluentState $state) use ($owner, $locale, $copyRelations): void {
+                static function (FluentState $state) use ($owner, $ownerVersioned, $locale, $copyRelations): void {
                     $state->setLocale($locale);
 
                     $localisedOwner = DataObject::get($owner->ClassName)->byID($owner->ID);
 
                     // Couldn't find localised data to work with
-                    if (!$localisedOwner->exists()) {
+                    if (!$localisedOwner) {
                         return;
                     }
 
                     // Duplicate all localised relations
                     foreach ($copyRelations as $relation) {
-                        $original = $localisedOwner->{$relation}();
+                        $originalRelation = $localisedOwner->getComponent($relation);
 
-                        if (!$original instanceof DataObject) {
+                        if (!$originalRelation instanceof DataObject) {
                             continue;
                         }
 
-                        if (!$original->exists()) {
+                        if (!$originalRelation->isInDB()) {
                             continue;
                         }
 
-                        $duplicate = $original->duplicate();
+                        $duplicate = $originalRelation->duplicate(false);
                         $localisedOwner->setComponent($relation, $duplicate);
                     }
 
                     // Update localised data (without version as this is considered a part of the duplication action)
-                    $localisedOwner->hasExtension(Versioned::class)
-                        ? $localisedOwner->writeWithoutVersion()
-                        : $localisedOwner->write();
+                    $localisedOwner->withLocalisedCopyState(function () use ($ownerVersioned, $localisedOwner): void {
+                        // Prevent unintended interactions with localised copy feature
+                        $localisedOwner->setLocalisedCopyActive(false);
+                        $ownerVersioned
+                            ? $localisedOwner->writeWithoutVersion()
+                            : $localisedOwner->write();
+                    });
                 }
             );
         }

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -698,7 +698,7 @@ class FluentExtension extends DataExtension
             return;
         }
 
-        $locales = $this->getLocaleCodesFormModel($owner);
+        $locales = $this->getLocaleCodesForModel($owner);
 
         // Current locale can be skipped as it was already handled correctly
         $locales = array_diff($locales, [$currentLocale]);
@@ -1590,7 +1590,7 @@ class FluentExtension extends DataExtension
      * @param DataObject $model
      * @return array
      */
-    private function getLocaleCodesFormModel(DataObject $model): array
+    private function getLocaleCodesForModel(DataObject $model): array
     {
         $locales = [];
 

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -725,6 +725,7 @@ class FluentExtension extends DataExtension
 
                     // Duplicate all localised relations
                     foreach ($copyRelations as $relation) {
+                        $localisedRelation = $localisedOwner->getComponent($relation);
                         $originalRelation = $localisedOriginal->getComponent($relation);
 
                         if (!$originalRelation instanceof DataObject) {
@@ -735,7 +736,24 @@ class FluentExtension extends DataExtension
                             continue;
                         }
 
-                        $duplicate = $originalRelation->duplicate(false);
+                        // Determine if Top page ID information is available
+                        $topPageID = (int) $localisedRelation->hasField('TopPageID')
+                            ? $localisedRelation->TopPageID
+                            : 0;
+
+                        // Elemental module compatibility
+                        if ($topPageID && $originalRelation->hasMethod('withFixedTopPage')) {
+                            $duplicate = $originalRelation->withFixedTopPage(
+                                $topPageID,
+                                static function () use ($originalRelation): DataObject {
+                                    // Duplicate needs to include write to store the top page data
+                                    return $originalRelation->duplicate();
+                                }
+                            );
+                        } else {
+                            $duplicate = $originalRelation->duplicate();
+                        }
+
                         $localisedOwner->setComponent($relation, $duplicate);
                     }
 

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -737,7 +737,7 @@ class FluentExtension extends DataExtension
 
                     $localisedOwner = DataObject::get($owner->ClassName)->byID($owner->ID);
 
-                    // Couldn't find localised to to work with
+                    // Couldn't find localised data to work with
                     if (!$localisedOwner->exists()) {
                         return;
                     }

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -3,7 +3,6 @@
 namespace TractorCow\Fluent\Extension;
 
 use LogicException;
-use SilverStripe\i18n\i18n;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
@@ -26,7 +25,6 @@ use SilverStripe\ORM\Queries\SQLConditionGroup;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\ORM\Queries\SQLUpdate;
 use SilverStripe\ORM\ValidationException;
-use SilverStripe\Security\Permission;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\HTML;
 use TractorCow\Fluent\Extension\Traits\FluentObjectTrait;
@@ -725,28 +723,18 @@ class FluentExtension extends DataExtension
 
                     // Duplicate all localised relations
                     foreach ($copyHasOneRelations as $relation => $relationIDField) {
-                        $localisedRelation = $localisedOwner->getComponent($relation);
                         $originalRelation = $localisedOriginal->getComponent($relation);
 
                         if (!$originalRelation->isInDB()) {
                             continue;
                         }
 
-                        // Determine if Top page ID information is available
-                        $topPageID = (int) $localisedRelation->hasField('TopPageID')
-                            ? $localisedRelation->TopPageID
-                            : 0;
+                        // Allow an extension point to populate the duplicate first
+                        $duplicate = null;
+                        $originalRelation->extend('onBeforeDuplicateToLocale', $relation, $relationIDField, $localisedOwner, $duplicate);
 
-                        // Elemental module compatibility
-                        if ($topPageID && $originalRelation->hasExtension(\DNADesign\Elemental\TopPage\DataExtension::class)) {
-                            $duplicate = $originalRelation->withFixedTopPage(
-                                $topPageID,
-                                static function () use ($originalRelation): DataObject {
-                                    // Duplicate needs to include write to store the top page data
-                                    return $originalRelation->duplicate();
-                                }
-                            );
-                        } else {
+                        // If extension point fails to provide a duplicate, fall back to the default duplication
+                        if (!$duplicate instanceof DataObject) {
                             $duplicate = $originalRelation->duplicate(false);
                         }
 

--- a/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
+++ b/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
@@ -242,10 +242,11 @@ class DuplicationTest extends SapphireTest
     /**
      * case: duplicate() called on localised record
      * desired outcome: has_one duplication is copied correctly to localised table
+     * @dataProvider duplicationCasesProvider
      */
-    public function testDuplicate(): void
+    public function testDuplicate(?array $relations): void
     {
-        FluentState::singleton()->withState(function (FluentState $state): void {
+        FluentState::singleton()->withState(function (FluentState $state) use ($relations): void {
             $state->setLocale('en_NZ');
 
             /** @var Horse|FluentExtension $originalHorse */
@@ -271,7 +272,7 @@ class DuplicationTest extends SapphireTest
             $ribbonCountBefore = Ribbon::get()->count();
 
             // Duplicate the horse (and its tail by association)
-            $duplicateHorse = $originalHorse->duplicate();
+            $duplicateHorse = $originalHorse->duplicate(true, $relations);
             $duplicateHorseID = $duplicateHorse->ID;
 
             $horseCountAfter = Horse::get()->count();
@@ -283,6 +284,23 @@ class DuplicationTest extends SapphireTest
                 'en_NZ',
                 'ja_JP',
             ];
+
+            // In case we explicitly chose to not duplicate relations we do not expect duplicated models to be present
+            if ($relations === []) {
+                $this->assertEquals(
+                    $tailsCountBefore,
+                    $tailsCountAfter,
+                    'We do not expect a duplicate to be created (Tail)'
+                );
+                $this->assertEquals(
+                    $ribbonCountBefore,
+                    $ribbonCountAfter,
+                    'We do not expect a duplicate to be created (Ribbon)'
+                );
+
+                return;
+            }
+
             $localesCount = count($locales);
             $this->assertEquals(
                 $tailsCountBefore + $localesCount,
@@ -340,6 +358,23 @@ class DuplicationTest extends SapphireTest
             $this->assertCount($localesCount, $localisedRibbonIDs, 'We expect unique ribbon ID in each locale');
             $this->assertCount($localesCount, $localisedRibbonTitles, 'We expect unique ribbon titles in each locale');
         });
+    }
+
+    public function duplicationCasesProvider(): array
+    {
+        return [
+            'default duplicaton' => [
+                null,
+            ],
+            'explicit duplicaton (specific relation)' => [
+                [
+                    'Tail',
+                ],
+            ],
+            'explicit duplicaton (no relation)' => [
+                [],
+            ],
+        ];
     }
 
     public function localesProvider(): array

--- a/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
+++ b/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
@@ -250,7 +250,7 @@ class DuplicationTest extends SapphireTest
             /** @var Horse|FluentExtension $originalHorse */
             $originalHorse = $this->objFromFixture(Horse::class, 'horse1');
 
-            // We need a second locale to be present before duplication so we can cover alll cases
+            // We need a second locale to be present before duplication so we can cover all cases
             $originalHorse->copyToLocale('ja_JP');
 
             $tail = $originalHorse->Tail();

--- a/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
+++ b/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
@@ -253,6 +253,16 @@ class DuplicationTest extends SapphireTest
 
             // We need a second locale to be present before duplication so we can cover all cases
             $originalHorse->copyToLocale('ja_JP');
+            FluentState::singleton()->withState(function (FluentState $state) use ($originalHorse): void {
+                $state->setLocale('en_NZ');
+
+                /** @var Horse $localisedHorse */
+                $localisedHorse = Horse::get()->byID($originalHorse->ID);
+                $ribbon = $localisedHorse->Tail()->Ribbon();
+                // Make sure we have a different title in JP locale so we can assert this later
+                $ribbon->Title .= ' JP';
+                $ribbon->write();
+            });
 
             $tail = $originalHorse->Tail();
             $originalTailID = $tail->ID;
@@ -292,11 +302,13 @@ class DuplicationTest extends SapphireTest
 
             $localisedTailIDs = [];
             $localisedRibbonIDs = [];
+            $localisedRibbonTitles = [];
 
             foreach ($locales as $locale) {
                 [
                     $localisedTailID,
                     $localisedRibbonID,
+                    $localisedRibbonTitle,
                 ] = FluentState::singleton()->withState(
                     function (FluentState $state) use ($locale, $originalHorse, $duplicateHorseID): array {
                         $state->setLocale($locale);
@@ -306,21 +318,27 @@ class DuplicationTest extends SapphireTest
                         $this->assertNotSame($originalHorse->TailID, $duplicateHorse->TailID);
                         $this->assertNotSame($originalHorse->Tail()->RibbonID, $duplicateHorse->Tail()->RibbonID);
 
+                        $tail = $duplicateHorse->Tail();
+                        $ribbon = $tail->Ribbon();
+
                         return [
                             $duplicateHorse->TailID,
-                            $duplicateHorse->Tail()->RibbonID,
+                            $ribbon->ID,
+                            $ribbon->Title,
                         ];
                     }
                 );
 
                 $localisedTailIDs[] = $localisedTailID;
                 $localisedRibbonIDs[] = $localisedRibbonID;
+                $localisedRibbonTitles[] = $localisedRibbonTitle;
             }
 
             $localisedTailIDs = array_unique($localisedTailIDs);
             $localisedRibbonIDs = array_unique($localisedRibbonIDs);
             $this->assertCount($localesCount, $localisedTailIDs, 'We expect unique tail ID in each locale');
             $this->assertCount($localesCount, $localisedRibbonIDs, 'We expect unique ribbon ID in each locale');
+            $this->assertCount($localesCount, $localisedRibbonTitles, 'We expect unique ribbon titles in each locale');
         });
     }
 

--- a/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
+++ b/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
@@ -249,6 +249,10 @@ class DuplicationTest extends SapphireTest
 
             /** @var Horse|FluentExtension $originalHorse */
             $originalHorse = $this->objFromFixture(Horse::class, 'horse1');
+
+            // We need a second locale to be present before duplication so we can cover alll cases
+            $originalHorse->copyToLocale('ja_JP');
+
             $tail = $originalHorse->Tail();
             $originalTailID = $tail->ID;
             $horseCountBefore = Horse::get()->count();
@@ -256,19 +260,48 @@ class DuplicationTest extends SapphireTest
 
             // Duplicate the horse (and its tail by association)
             $duplicateHorse = $originalHorse->duplicate();
+            $duplicateHorseID = $duplicateHorse->ID;
 
             $horseCountAfter = Horse::get()->count();
             $tailsCountAfter = Tail::get()->count();
+
             $this->assertEquals($horseCountBefore + 1, $horseCountAfter);
-            $this->assertEquals($tailsCountBefore + 1, $tailsCountAfter);
+            $locales = [
+                'en_NZ',
+                'ja_JP',
+            ];
+            $localesCount = count($locales);
+            $this->assertEquals(
+                $tailsCountBefore + $localesCount,
+                $tailsCountAfter,
+                'We expect a duplicate to be created for each locale'
+            );
 
             // Re-fetch both horses so we are asserting on what's in the DB not just what's in memory
             $originalHorse = Horse::get()->byID($originalHorse->ID);
-            $duplicateHorse = Horse::get()->byID($duplicateHorse->ID);
 
-            $this->assertNotSame($originalHorse->ID, $duplicateHorse->ID);
-            $this->assertNotSame($originalHorse->TailID, $duplicateHorse->TailID);
             $this->assertSame($originalTailID, $originalHorse->TailID);
+
+            $localisedTailIDs = [];
+
+            foreach ($locales as $locale) {
+                $localisedTailID = FluentState::singleton()->withState(
+                    function (FluentState $state) use ($locale, $originalHorse, $duplicateHorseID): int {
+                        $state->setLocale($locale);
+
+                        $duplicateHorse = Horse::get()->byID($duplicateHorseID);
+                        $this->assertNotSame($originalHorse->ID, $duplicateHorse->ID);
+                        $this->assertNotSame($originalHorse->TailID, $duplicateHorse->TailID);
+
+                        return $duplicateHorse->TailID;
+                    }
+                );
+
+                $localisedTailIDs[] = $localisedTailID;
+            }
+
+            $localisedTailIDs = array_unique($localisedTailIDs);
+            $this->assertCount($localesCount, $localisedTailIDs, 'We expect unique tail ID in each locale');
         });
     }
 

--- a/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
+++ b/tests/php/Extension/LocalisedCopyTest/DuplicationTest.php
@@ -21,6 +21,7 @@ class DuplicationTest extends SapphireTest
         Horse::class,
         Steed::class,
         Tail::class,
+        Ribbon::class,
         Saddle::class,
     ];
 
@@ -257,6 +258,7 @@ class DuplicationTest extends SapphireTest
             $originalTailID = $tail->ID;
             $horseCountBefore = Horse::get()->count();
             $tailsCountBefore = Tail::get()->count();
+            $ribbonCountBefore = Ribbon::get()->count();
 
             // Duplicate the horse (and its tail by association)
             $duplicateHorse = $originalHorse->duplicate();
@@ -264,6 +266,7 @@ class DuplicationTest extends SapphireTest
 
             $horseCountAfter = Horse::get()->count();
             $tailsCountAfter = Tail::get()->count();
+            $ribbonCountAfter = Ribbon::get()->count();
 
             $this->assertEquals($horseCountBefore + 1, $horseCountAfter);
             $locales = [
@@ -274,7 +277,12 @@ class DuplicationTest extends SapphireTest
             $this->assertEquals(
                 $tailsCountBefore + $localesCount,
                 $tailsCountAfter,
-                'We expect a duplicate to be created for each locale'
+                'We expect a duplicate to be created for each locale (Tail)'
+            );
+            $this->assertEquals(
+                $ribbonCountBefore + $localesCount,
+                $ribbonCountAfter,
+                'We expect a duplicate to be created for each locale (Ribbon)'
             );
 
             // Re-fetch both horses so we are asserting on what's in the DB not just what's in memory
@@ -283,25 +291,36 @@ class DuplicationTest extends SapphireTest
             $this->assertSame($originalTailID, $originalHorse->TailID);
 
             $localisedTailIDs = [];
+            $localisedRibbonIDs = [];
 
             foreach ($locales as $locale) {
-                $localisedTailID = FluentState::singleton()->withState(
-                    function (FluentState $state) use ($locale, $originalHorse, $duplicateHorseID): int {
+                [
+                    $localisedTailID,
+                    $localisedRibbonID,
+                ] = FluentState::singleton()->withState(
+                    function (FluentState $state) use ($locale, $originalHorse, $duplicateHorseID): array {
                         $state->setLocale($locale);
 
                         $duplicateHorse = Horse::get()->byID($duplicateHorseID);
                         $this->assertNotSame($originalHorse->ID, $duplicateHorse->ID);
                         $this->assertNotSame($originalHorse->TailID, $duplicateHorse->TailID);
+                        $this->assertNotSame($originalHorse->Tail()->RibbonID, $duplicateHorse->Tail()->RibbonID);
 
-                        return $duplicateHorse->TailID;
+                        return [
+                            $duplicateHorse->TailID,
+                            $duplicateHorse->Tail()->RibbonID,
+                        ];
                     }
                 );
 
                 $localisedTailIDs[] = $localisedTailID;
+                $localisedRibbonIDs[] = $localisedRibbonID;
             }
 
             $localisedTailIDs = array_unique($localisedTailIDs);
+            $localisedRibbonIDs = array_unique($localisedRibbonIDs);
             $this->assertCount($localesCount, $localisedTailIDs, 'We expect unique tail ID in each locale');
+            $this->assertCount($localesCount, $localisedRibbonIDs, 'We expect unique ribbon ID in each locale');
         });
     }
 

--- a/tests/php/Extension/LocalisedCopyTest/DuplicationTest.yml
+++ b/tests/php/Extension/LocalisedCopyTest/DuplicationTest.yml
@@ -1,30 +1,35 @@
 TractorCow\Fluent\Model\Locale:
   nz:
-    Locale: en_NZ
+    Locale: 'en_NZ'
     Title: 'English NZ'
-    URLSegment: nz
+    URLSegment: 'nz'
   jp:
-    Locale: ja_JP
+    Locale: 'ja_JP'
     Title: 'Japan'
-    URLSegment: jp
+    URLSegment: 'jp'
+
+TractorCow\Fluent\Tests\Extension\LocalisedCopyTest\Ribbon:
+  ribbon1:
+    Title: 'Ribbon1'
 
 TractorCow\Fluent\Tests\Extension\LocalisedCopyTest\Tail:
   tail1:
-    Title: Tail1
+    Title: 'Tail1'
+    Ribbon: =>TractorCow\Fluent\Tests\Extension\LocalisedCopyTest\Ribbon.ribbon1
   tail2:
-    Title: Tail2
+    Title: 'Tail2'
 
 TractorCow\Fluent\Tests\Extension\LocalisedCopyTest\Saddle:
   saddle1:
-    Title: Saddle1
+    Title: 'Saddle1'
 
 TractorCow\Fluent\Tests\Extension\LocalisedCopyTest\Horse:
   horse1:
-    Title: Horse1
+    Title: 'Horse1'
     Tail: =>TractorCow\Fluent\Tests\Extension\LocalisedCopyTest\Tail.tail1
 
 TractorCow\Fluent\Tests\Extension\LocalisedCopyTest\Steed:
   steed1:
-    Title: Steed1
+    Title: 'Steed1'
     Tail: =>TractorCow\Fluent\Tests\Extension\LocalisedCopyTest\Tail.tail2
     Saddle: =>TractorCow\Fluent\Tests\Extension\LocalisedCopyTest\Saddle.saddle1

--- a/tests/php/Extension/LocalisedCopyTest/Ribbon.php
+++ b/tests/php/Extension/LocalisedCopyTest/Ribbon.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Extension\LocalisedCopyTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * @method Tail Parent()
+ */
+class Ribbon extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'Ribbon';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar(255)',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $belongs_to = [
+        'Parent' => Tail::class . '.Ribbon',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $owned_by = [
+        'Parent',
+    ];
+}

--- a/tests/php/Extension/LocalisedCopyTest/Tail.php
+++ b/tests/php/Extension/LocalisedCopyTest/Tail.php
@@ -6,8 +6,8 @@ use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 
 /**
- * Class Tail
- *
+ * @property int RibbonID
+ * @method Ribbon Ribbon()
  * @method Horse Parent()
  */
 class Tail extends DataObject implements TestOnly
@@ -27,6 +27,13 @@ class Tail extends DataObject implements TestOnly
     /**
      * @var array
      */
+    private static $has_one = [
+        'Ribbon' => Ribbon::class,
+    ];
+
+    /**
+     * @var array
+     */
     private static $belongs_to = [
         'Parent' => Horse::class . '.Tail',
     ];
@@ -34,7 +41,28 @@ class Tail extends DataObject implements TestOnly
     /**
      * @var array
      */
+    private static $owns = [
+        'Ribbon',
+    ];
+
+    /**
+     * @var array
+     */
     private static $owned_by = [
         'Parent',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $cascade_deletes = [
+        'Ribbon',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $cascade_duplicates = [
+        'Ribbon',
     ];
 }


### PR DESCRIPTION
# Multi locale localised copy correction.

Fixes https://github.com/tractorcow-farm/silverstripe-fluent/issues/940

Fix spans multiple modules. https://github.com/silverstripe/silverstripe-elemental/pull/1342