### PR TITLE
ENH Set Title and URLSegment fields on write

### DIFF
--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -8,6 +8,7 @@ use Exception;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
@@ -156,20 +157,6 @@ class Locale extends DataObject implements PermissionProvider
     }
 
     /**
-     * Get internal title for this locale
-     *
-     * @return string
-     */
-    public function getTitle()
-    {
-        $title = $this->getField('Title');
-        if ($title) {
-            return $title;
-        }
-        return $this->getDefaultTitle();
-    }
-
-    /**
      * Long title (including locale code)
      *
      * @return string
@@ -262,16 +249,12 @@ class Locale extends DataObject implements PermissionProvider
      * Get URLSegment for this locale
      *
      * @return string
+     * @deprecated 8.1.0 Use `URLSegment` database field directly instead.
      */
     public function getURLSegment()
     {
-        $segment = $this->getField('URLSegment');
-        if ($segment) {
-            return $segment;
-        }
-
-        // Default to locale
-        return $this->getLocale();
+        Deprecation::notice('8.1.0', 'Use `URLSegment` database field directly instead.');
+        return $this->getField('URLSegment');
     }
 
     public function getCMSFields()
@@ -497,6 +480,19 @@ class Locale extends DataObject implements PermissionProvider
         }
 
         return Locale::getCached();
+    }
+
+    protected function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+
+        // Set Title and URLSegment to reflect the locale if not specified.
+        if (!$this->Title) {
+            $this->Title = $this->getDefaultTitle();
+        }
+        if (!$this->URLSegment) {
+            $this->URLSegment = $this->getLocale();
+        }
     }
 
     protected function onAfterWrite()

--- a/tests/php/Model/LocaleTest.php
+++ b/tests/php/Model/LocaleTest.php
@@ -11,6 +11,7 @@ use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Forms\Form;
 
 class LocaleTest extends SapphireTest
 {
@@ -220,5 +221,38 @@ class LocaleTest extends SapphireTest
         $locale = Locale::getByLocale('es_US');
 
         $this->assertSame('US', $locale->getLocaleSuffix());
+    }
+
+    public static function provideDefaultValues(): array
+    {
+        return [
+            [
+                'locale' => 'en_US',
+                'title' => 'English (United States)',
+                'urlSegment' => 'en_US',
+            ],
+            [
+                'locale' => 'en_NZ',
+                'title' => 'English (New Zealand)',
+                'urlSegment' => 'en_NZ',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideDefaultValues')]
+    public function testDefaultValues(string $locale, string $title, string $urlSegment): void
+    {
+        // Simulate creating a new record via the CMS
+        $localeObj = new Locale();
+        $form = new Form(fields: $localeObj->getCMSFields());
+        $form->loadDataFrom($localeObj);
+        $form->saveInto($localeObj);
+        // Setting this must be done after putting data into and out of the form.
+        // This ensures values weren't set into the form via getters that fetch a default value too early.
+        $localeObj->Locale = $locale;
+        $localeObj->write();
+
+        $this->assertSame($title, $localeObj->Title);
+        $this->assertSame($urlSegment, $localeObj->URLSegment);
     }
 }


### PR DESCRIPTION
Currently the logic will automatically set the value for the Title and URLSegment form fields based on the default locale.

These should instead be set to the locale that is chosen unless otherwise explicitly overridden.

Note that this is targetting `8` to be included in a future `8.1` minor release.

## Issue
- https://github.com/tractorcow-farm/silverstripe-fluent/issues/944