### PR TITLE
fix: update fluent form actions if there is FluentState

### DIFF
--- a/src/Extension/FluentGridFieldExtension.php
+++ b/src/Extension/FluentGridFieldExtension.php
@@ -14,6 +14,7 @@ use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Versioned\VersionedGridFieldItemRequest;
 use TractorCow\Fluent\Extension\Traits\FluentAdminTrait;
 use TractorCow\Fluent\Extension\Traits\FluentBadgeTrait;
+use TractorCow\Fluent\State\FluentState;
 
 /**
  * Supports GridFieldDetailForm_ItemRequest with extra actions
@@ -39,6 +40,11 @@ class FluentGridFieldExtension extends Extension
 
     public function updateFormActions(FieldList $actions)
     {
+        // If there is no current FluentState, then we shouldn't update.
+        if (!FluentState::singleton()->getLocale()) {
+            return;
+        }
+        
         $this->updateFluentActions($actions, $this->owner->getRecord());
     }
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
"Localise" cms action button is visible in grid field records when there is no Fluent locales setup. Just checked the current FluentState presents as done in `FluentSiteTreeExtension::updateCMSActions()`

## Manual testing steps

- Create a test DataObject
- Add some data in cms
- Install Fluent module and dev/build
- If you open a data record in cms you'll see "Localise" button rather than "Save" button


## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
