### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/admin": "^3",
         "silverstripe/versioned": "^3",
         "symbiote/silverstripe-gridfieldextensions": "^5",

--- a/src/Extension/FluentCMSMainExtension.php
+++ b/src/Extension/FluentCMSMainExtension.php
@@ -126,7 +126,7 @@ class FluentCMSMainExtension extends Extension
         }
 
         /** @var DataObject|FluentVersionedExtension $record */
-        $record = DataObject::get_by_id($className, $id);
+        $record = DataObject::get($className)->setUseCache(true)->byID($id);
 
         if ($record === null) {
             // No record

--- a/src/Extension/Traits/FluentAdminTrait.php
+++ b/src/Extension/Traits/FluentAdminTrait.php
@@ -720,7 +720,7 @@ trait FluentAdminTrait
         $liveRecord = Versioned::withVersionedMode(function () use ($record) {
             Versioned::set_stage(Versioned::LIVE);
 
-            return DataObject::get_by_id($record->ClassName, $record->ID);
+            return DataObject::get($record->ClassName)->setUseCache(true)->byID($record->ID);
         });
 
         $infoTemplate = SSViewer::get_templates_by_class(

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -388,7 +388,6 @@ class Locale extends DataObject implements PermissionProvider
     public static function getCurrentLocale(): ?Locale
     {
         $locale = FluentState::singleton()->getLocale();
-
         return static::getByLocale($locale);
     }
 
@@ -409,7 +408,7 @@ class Locale extends DataObject implements PermissionProvider
         }
 
         // Get filtered locale
-        return Locale::getCached()->find('Locale', $locale);
+        return Locale::get()->setUseCache(true)->find('Locale', $locale);
     }
 
     /**

--- a/src/Task/InitialDataObjectLocalisationTask.php
+++ b/src/Task/InitialDataObjectLocalisationTask.php
@@ -190,7 +190,7 @@ class InitialDataObjectLocalisationTask extends BuildTask
                     $isBaseRecordPublished = FluentState::singleton()->withState(
                         static function (FluentState $state) use ($className, $dataObjectID): bool {
                             $state->setLocale(null);
-                            $page = $className::get_by_id($dataObjectID);
+                            $page = $className::get()->setUseCache(true)->byID($dataObjectID);
 
                             if ($page === null) {
                                 return false;


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

Also caches the current locale object separately from the `getCached()` result set.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
