### PR TITLE
MNT Add tests for generated columns

### DIFF
--- a/tests/php/Extension/FluentExtensionTest.php
+++ b/tests/php/Extension/FluentExtensionTest.php
@@ -20,6 +20,7 @@ use TractorCow\Fluent\Tests\Extension\FluentExtensionTest\TestRelationPage;
 use TractorCow\Fluent\Tests\Extension\FluentExtensionTest\UnlocalisedChild;
 use TractorCow\Fluent\Tests\Extension\Stub\FluentStubObject;
 use PHPUnit\Framework\Attributes\DataProvider;
+use TractorCow\Fluent\Tests\Extension\FluentExtensionTest\TestGeneratedColumns;
 
 class FluentExtensionTest extends SapphireTest
 {
@@ -33,6 +34,7 @@ class FluentExtensionTest extends SapphireTest
         UnlocalisedChild::class,
         TestRelationPage::class,
         TestModel::class,
+        TestGeneratedColumns::class,
     ];
 
     protected static $required_extensions = [
@@ -508,6 +510,45 @@ class FluentExtensionTest extends SapphireTest
                 true,
             ]
         ];
+    }
+
+    public function testLocalisedGeneratedColumns(): void
+    {
+        // Setup first localisation
+        $recordID = FluentState::singleton()->withState(function (FluentState $state): int {
+            $state->setLocale('en_US');
+
+            $record = new TestGeneratedColumns();
+            $record->BaseField = 'EN copy test';
+            return $record->write();
+        });
+
+        // Setup second localisation and make sure we have two localisations to work with
+        FluentState::singleton()->withState(function (FluentState $state) use ($recordID): void {
+            $state->setLocale('de_DE');
+
+            $record = TestGeneratedColumns::get()->byID($recordID);
+            $record->BaseField = 'DE copy test';
+            $record->write();
+        });
+
+        // Check the values of the generated columns in en_US
+        FluentState::singleton()->withState(function (FluentState $state) use ($recordID): void {
+            $state->setLocale('en_US');
+
+            $record = TestGeneratedColumns::get()->byID($recordID);
+            $this->assertSame('EN copy test_virtual', $record->GeneratedField1);
+            $this->assertSame('EN copy test_stored', $record->GeneratedField2);
+        });
+
+        // Check the values of the generated columns in de_DE
+        FluentState::singleton()->withState(function (FluentState $state) use ($recordID): void {
+            $state->setLocale('de_DE');
+
+            $record = TestGeneratedColumns::get()->byID($recordID);
+            $this->assertSame('DE copy test_virtual', $record->GeneratedField1);
+            $this->assertSame('DE copy test_stored', $record->GeneratedField2);
+        });
     }
 
     /**

--- a/tests/php/Extension/FluentExtensionTest/TestGeneratedColumns.php
+++ b/tests/php/Extension/FluentExtensionTest/TestGeneratedColumns.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Extension\FluentExtensionTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use TractorCow\Fluent\Extension\FluentExtension;
+
+/**
+ * @mixin FluentExtension
+ */
+class TestGeneratedColumns extends DataObject implements TestOnly
+{
+    private static string $table_name = 'FluentExtensionTest_TestGeneratedColumns';
+
+    private static array $db = [
+        'BaseField' => 'Varchar(255)',
+        'GeneratedField1' => 'Generated("Varchar(255)", "CONCAT(\\"BaseField\\", \'_virtual\')", "VIRTUAL")',
+        'GeneratedField2' => 'Generated("Varchar(255)", "CONCAT(\\"BaseField\\", \'_stored\')", "STORED")',
+    ];
+
+    private static array $extensions = [
+        FluentExtension::class,
+    ];
+
+    private static $translate = [
+        'BaseField',
+        'GeneratedField1',
+        'GeneratedField2',
+    ];
+}


### PR DESCRIPTION
Mostly added to ensure exceptions won't be thrown since augmentWrite can bypass `DBField::writeToManipulation()`

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11774 for CI to go green
> Do not merge until after that PR has been merged

## Issue

- https://github.com/silverstripe/silverstripe-assets/issues/693