### PR TITLE
ENH Optimise SQL queries to improve performance

### DIFF
--- a/src/Extension/FluentGridFieldExtension.php
+++ b/src/Extension/FluentGridFieldExtension.php
@@ -43,7 +43,7 @@ class FluentGridFieldExtension extends Extension
 
         // Return new view, as we can't do a "virtual redirect" via the CMS Ajax
         // to the same URL (it assumes that its content is already current, and doesn't reload)
-        if ($gridField->getList()->byID($record->ID)) {
+        if ($gridField->getList()->filter('ID', $record->ID)->exists()) {
             return $this->owner->edit($request);
         }
 

--- a/src/Model/Domain.php
+++ b/src/Model/Domain.php
@@ -211,7 +211,7 @@ class Domain extends DataObject
         }
 
         // Unset if not in child list
-        $inList = $this->Locales()->byID($default->ID);
+        $inList = $this->Locales()->filter('ID', $default->ID)->exists();
         if (!$inList) {
             $this->DefaultLocaleID = 0;
         }


### PR DESCRIPTION
While not reducing the _number_ of queries, I've updated a bunch of calls to `find()` and `byID()` (which were only being used to check if a record exists) to instead use `filter()->exists()` which is more efficient.

## Issue

- https://github.com/silverstripe/.github/issues/416