### PR TITLE
FIX Ensure Version column is included in draft_localised table

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -151,6 +151,15 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
         DB::require_table($localisedTable . FluentVersionedExtension::SUFFIX_VERSIONS, $versionsFields, $versionsIndexes, false);
     }
 
+    protected function isFieldLocalised($field, $type, $class)
+    {
+        // Explicitly localise version columns, which are necessary for some versioning functionality to work correctly.
+        if (array_key_exists($field, $this->defaultVersionsFields)) {
+            return true;
+        }
+        return parent::isFieldLocalised($field, $type, $class);
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.yml
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.yml
@@ -54,22 +54,3 @@ Page:
     Title: Staff
     URLSegment: my-staff
     Parent: =>Page.about
-
-SiteTree_Localised:
-  nz-page:
-    RecordID: =>Page.nz-page
-    Title: A Page
-    URLSegment: a-page
-    Locale: de_DE
-  about:
-    RecordID: =>Page.about
-    Title: About Us
-    URLSegment: about-us
-    Locale: de_DE
-
-SiteTree_Localised_Live:
-  nz-page:
-    RecordID: =>Page.nz-page
-    Title: A Page
-    URLSegment: a-page
-    Locale: de_DE

--- a/tests/php/Extension/FluentVersionedExtensionTest.php
+++ b/tests/php/Extension/FluentVersionedExtensionTest.php
@@ -11,10 +11,15 @@ use TractorCow\Fluent\Extension\FluentVersionedExtension;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
+use TractorCow\Fluent\Tests\Extension\FluentVersionedExtensionTest\TestVersionedModel;
 
 class FluentVersionedExtensionTest extends SapphireTest
 {
     protected static $fixture_file = 'FluentVersionedExtensionTest.yml';
+
+    protected static $extra_dataobjects = [
+        TestVersionedModel::class
+    ];
 
     protected static $required_extensions = [
         SiteTree::class => [
@@ -205,5 +210,165 @@ class FluentVersionedExtensionTest extends SapphireTest
 
         // No Live version
         $this->assertTrue($page->stagesDifferInLocale());
+    }
+
+    /**
+     * Tests various Versioned methods correctly identify versions in different locales
+     */
+    public function testCorrectVersionIdentified(): void
+    {
+        $recordID = null;
+        // Create a new record in the base record only, no localisation
+        FluentState::singleton()->withState(function (FluentState $newState) use (&$recordID) {
+            $newState->setLocale(null);
+            $record = new TestVersionedModel(['Title' => 'Initial value']);
+            $recordID = $record->write();
+
+            // True for anything about being on draft and not published
+            $this->assertTrue($record->isOnDraft());
+            $this->assertFalse($record->isPublished());
+            $this->assertTrue($record->isLatestDraftVersion());
+            $this->assertTrue($record->isLatestVersion());
+            $this->assertFalse($record->isLiveVersion());
+            $this->assertTrue($record->isModifiedOnDraft());
+            $this->assertFalse($record->isOnLiveOnly());
+        });
+
+        // Check all false - it's not in this locale at all yet.
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_NZ');
+            $localisedRecord = TestVersionedModel::get()->byID($recordID);
+            $this->assertFalse($localisedRecord->isOnDraft());
+            $this->assertFalse($localisedRecord->isPublished());
+            $this->assertFalse($localisedRecord->isLatestDraftVersion());
+            $this->assertFalse($localisedRecord->isLatestVersion());
+            $this->assertFalse($localisedRecord->isLiveVersion());
+            $this->assertFalse($localisedRecord->isModifiedOnDraft());
+            $this->assertFalse($localisedRecord->isOnLiveOnly());
+        });
+
+        // Publish in the base record only, no localisation
+        FluentState::singleton()->withState(function (FluentState $newState) use (&$recordID) {
+            $newState->setLocale(null);
+            $record = TestVersionedModel::get()->byID($recordID);
+            $record->publishSingle();
+
+            // True for anything about being published and "on draft" (i.e. not deleted from draft)
+            $this->assertTrue($record->isOnDraft());
+            $this->assertTrue($record->isPublished());
+            $this->assertTrue($record->isLatestDraftVersion());
+            $this->assertTrue($record->isLatestVersion());
+            $this->assertTrue($record->isLiveVersion());
+            $this->assertFalse($record->isModifiedOnDraft());
+            $this->assertFalse($record->isOnLiveOnly());
+        });
+
+        // Check still all false - it's not in this locale at all yet.
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_NZ');
+            $localisedRecord = TestVersionedModel::get()->byID($recordID);
+            $this->assertFalse($localisedRecord->isOnDraft());
+            $this->assertFalse($localisedRecord->isPublished());
+            $this->assertFalse($localisedRecord->isLatestDraftVersion());
+            $this->assertFalse($localisedRecord->isLatestVersion());
+            $this->assertFalse($localisedRecord->isLiveVersion());
+            $this->assertFalse($localisedRecord->isModifiedOnDraft());
+            $this->assertFalse($localisedRecord->isOnLiveOnly());
+        });
+
+        // Save the record in first locale
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_NZ');
+            $localisedRecord = TestVersionedModel::get()->byID($recordID);
+            $localisedRecord->write();
+
+            // True for anything about being on draft and not published
+            $this->assertTrue($localisedRecord->isOnDraft());
+            $this->assertFalse($localisedRecord->isPublished());
+            $this->assertTrue($localisedRecord->isLatestDraftVersion());
+            $this->assertTrue($localisedRecord->isLatestVersion());
+            $this->assertFalse($localisedRecord->isLiveVersion());
+            $this->assertTrue($localisedRecord->isModifiedOnDraft());
+            $this->assertFalse($localisedRecord->isOnLiveOnly());
+        });
+
+        // Check all false in *alternate* locale - it's not in this locale at all yet.
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_US');
+            $localisedRecord = TestVersionedModel::get()->byID($recordID);
+            $this->assertFalse($localisedRecord->isOnDraft());
+            $this->assertFalse($localisedRecord->isPublished());
+            $this->assertFalse($localisedRecord->isLatestDraftVersion());
+            $this->assertFalse($localisedRecord->isLatestVersion());
+            $this->assertFalse($localisedRecord->isLiveVersion());
+            $this->assertFalse($localisedRecord->isModifiedOnDraft());
+            $this->assertFalse($localisedRecord->isOnLiveOnly());
+
+            // Then save it in this locale
+            $localisedRecord->write();
+        });
+
+        // Publish the record in first locale
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_NZ');
+            $localisedRecord = TestVersionedModel::get()->byID($recordID);
+            $localisedRecord->publishSingle();
+
+            // True for anything about being published and "on draft" (i.e. not deleted from draft)
+            $this->assertTrue($localisedRecord->isOnDraft());
+            $this->assertTrue($localisedRecord->isPublished());
+            $this->assertTrue($localisedRecord->isLatestDraftVersion());
+            $this->assertTrue($localisedRecord->isLatestVersion());
+            $this->assertTrue($localisedRecord->isLiveVersion());
+            $this->assertFalse($localisedRecord->isModifiedOnDraft());
+            $this->assertFalse($localisedRecord->isOnLiveOnly());
+        });
+
+        // Check still only true for draft stuff in *alternate* locale
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_US');
+            $localisedRecord = TestVersionedModel::get()->byID($recordID);
+            $this->assertTrue($localisedRecord->isOnDraft());
+            $this->assertFalse($localisedRecord->isPublished());
+            $this->assertTrue($localisedRecord->isLatestDraftVersion());
+            $this->assertTrue($localisedRecord->isLatestVersion());
+            $this->assertFalse($localisedRecord->isLiveVersion());
+            $this->assertTrue($localisedRecord->isModifiedOnDraft());
+            $this->assertFalse($localisedRecord->isOnLiveOnly());
+
+            // Then publish it in this locale
+            $localisedRecord->publishSingle();
+        });
+
+        // Update, save, and publish the record in first locale
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_NZ');
+            $localisedRecord = TestVersionedModel::get()->byID($recordID);
+            $localisedRecord->Title = 'New value';
+            $localisedRecord->write();
+            $localisedRecord->publishSingle();
+
+            // True for anything about being published and "on draft" (i.e. not deleted from draft)
+            $this->assertTrue($localisedRecord->isOnDraft());
+            $this->assertTrue($localisedRecord->isPublished());
+            $this->assertTrue($localisedRecord->isLatestDraftVersion());
+            $this->assertTrue($localisedRecord->isLatestVersion());
+            $this->assertTrue($localisedRecord->isLiveVersion());
+            $this->assertFalse($localisedRecord->isModifiedOnDraft());
+            $this->assertFalse($localisedRecord->isOnLiveOnly());
+        });
+
+        // Check *alternate* locale still thinks it's published - and on the latest published version
+        FluentState::singleton()->withState(function (FluentState $newState) use ($recordID) {
+            $newState->setLocale('en_US');
+            $localisedRecord = TestVersionedModel::get()->byID($recordID);
+            $this->assertTrue($localisedRecord->isOnDraft());
+            $this->assertTrue($localisedRecord->isPublished());
+            $this->assertTrue($localisedRecord->isLatestDraftVersion());
+            $this->assertTrue($localisedRecord->isLatestVersion());
+            $this->assertTrue($localisedRecord->isLiveVersion());
+            $this->assertFalse($localisedRecord->isModifiedOnDraft());
+            $this->assertFalse($localisedRecord->isOnLiveOnly());
+        });
     }
 }

--- a/tests/php/Extension/FluentVersionedExtensionTest/TestVersionedModel.php
+++ b/tests/php/Extension/FluentVersionedExtensionTest/TestVersionedModel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace TractorCow\Fluent\Tests\Extension\FluentVersionedExtensionTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+use TractorCow\Fluent\Extension\FluentVersionedExtension;
+
+/**
+ * @mixin Versioned
+ */
+class TestVersionedModel extends DataObject implements TestOnly
+{
+    private static string $table_name = 'Fluent_TestVersionedModel';
+
+    private static array $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static array $extensions = [
+        Versioned::class,
+        FluentVersionedExtension::class,
+    ];
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Needs https://github.com/silverstripe/silverstripe-versioned/pull/526 to be merged for CI to go green. Merge that first, then rerun CI.

Various versioning functionality relies on having the correct Version value in the draft record - for example `Versioned::isLiveVersion()` checks the most recent live version against the current (usually draft) record version.

Fluent updates the values for `get_versionnumber_by_stage` through an extension hook, but this results in having the correctly localised live version number with the incorrect non-localised draft version number - which don't match.

Follow reproduction steps in the linked issue for testing. Note that due to https://github.com/silverstripe/silverstripe-elemental/issues/1266 you will need to add this workaround to allow you to edit the block:

```php
<?php

use SilverStripe\Core\Extension;
use SilverStripe\Forms\FieldList;

class BaseElementExtension extends Extension
{
    protected function updateCMSFields(FieldList $fields): void
    {
        if ($this->getOwner()::config()->get('inline_editable')) {
            $fields->removeByName('RecordLocales');
        }
    }
}
```

```yml
DNADesign\Elemental\Models\BaseElement:
  extensions:
    - 'BaseElementExtension'
```

## Issue

- https://github.com/tractorcow-farm/silverstripe-fluent/issues/913