### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/Extension/FluentReadVersionsExtensionTest.php
+++ b/tests/php/Extension/FluentReadVersionsExtensionTest.php
@@ -27,7 +27,6 @@ class FluentReadVersionsExtensionTest extends SapphireTest
 
             $extension = new FluentReadVersionsExtension();
             $method = new ReflectionMethod(FluentReadVersionsExtension::class, 'updateList');
-            $method->setAccessible(true);
             // Note this MUST be passed by reference, it cannot be changed not be passed by reference
             // in the extension method as the reference to the list is updated in the method
             $method->invokeArgs($extension, [&$list]);


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
