### PR TITLE
ENH Speed up query in stagesDifferInLocale by hinting the use of index

### DIFF
--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -432,7 +432,7 @@ class FluentVersionedExtension extends FluentExtension implements Resettable
         $query = <<<SQL
 SELECT "VL"."Version"
 FROM "$stagedTable" as "VL"
-INNER JOIN "$liveTable" as "V"
+INNER JOIN "$liveTable" as "V" USE INDEX (RecordID_VERSION)
     ON "VL"."RecordID" = "V"."RecordID"
     AND "VL"."Version" = "V"."Version"
 WHERE "VL"."RecordID" = ?


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

We found a case where the query in `stagesDifferInLocale` takes a long time to complete, because it is not using the right index.

The issue doesn't seem to occur for other accounts.  On closer look, the
site is waiting for the following SQL query

    SELECT VL.Version
      FROM LOExtension_Localised_Versions as VL
      INNER JOIN LOExtension_Versions as V
        ON VL.RecordID = V.RecordID AND VL.Version = V.Version
      WHERE VL.RecordID = 154 AND VL.Locale = 'en_US' AND V.WasPublished = 0
      ORDER BY VL.Version DESC
      LIMIT 1;

which takes about nearly 3 minutes(!) to complete, because `LIMIT 1`
lures MariaDB into not using the right index.  Compare the query plans
without the `LIMIT 1` (execution time 1.359s)

+------+-------------+-------+--------+-----------------------------------+---------------+---------+----------------------------------+------+-----------------------------+
| id   | select_type | table | type   | possible_keys                     | key           | key_len | ref                              | rows | Extra                       |
+------+-------------+-------+--------+-----------------------------------+---------------+---------+----------------------------------+------+-----------------------------+
|    1 | SIMPLE      | V     | ref    | RecordID_Version,RecordID,Version | RecordID      | 4       | const                            | 8414 | Using where; Using filesort |
|    1 | SIMPLE      | VL    | eq_ref | Fluent_Record,Fluent_Version      | Fluent_Record | 41      | const,const,extensions.V.Version | 1    | Using where; Using index    |
+------+-------------+-------+--------+-----------------------------------+---------------+---------+----------------------------------+------+-----------------------------+

and now with the `LIMIT 1` (execution time 165.333s)

+------+-------------+-------+--------+-----------------------------------+---------------+---------+----------------------------------+------+--------------------------+
| id   | select_type | table | type   | possible_keys                     | key           | key_len | ref                              | rows | Extra                    |
+------+-------------+-------+--------+-----------------------------------+---------------+---------+----------------------------------+------+--------------------------+
|    1 | SIMPLE      | V     | index  | RecordID_Version,RecordID,Version | Version       | 4       | NULL                             | 227  | Using where              |
|    1 | SIMPLE      | VL    | eq_ref | Fluent_Record,Fluent_Version      | Fluent_Record | 41      | const,const,extensions.V.Version | 1    | Using where; Using index |
+------+-------------+-------+--------+-----------------------------------+---------------+---------+----------------------------------+------+--------------------------+

Using an index hint to force MySQL to use the right index

    SELECT VL.Version
      FROM LOExtension_Localised_Versions as VL
      INNER JOIN LOExtension_Versions as V USE INDEX (RecordID_VERSION)
        ON VL.RecordID = V.RecordID AND VL.Version = V.Version
      WHERE VL.RecordID = 154 AND VL.Locale = 'en_US' AND V.WasPublished = 0
      ORDER BY VL.Version DESC
      LIMIT 1;

completes in 1.114s.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

Querying the modified queries directly in mysql client.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
