### PR TITLE
Fix incorrectly localised parent URL Segments in getLink()

### DIFF
--- a/src/Model/RecordLocale.php
+++ b/src/Model/RecordLocale.php
@@ -202,14 +202,19 @@ class RecordLocale extends ModelData
             return $this->getLocaleObject()->getBaseURL();
         }
 
-        // If original record implements LocaleLink, respect this
-        // note: hasMethod() will infinite loop, so don't use this.
-        if (method_exists($record, 'LocaleLink')) {
-            return $record->LocaleLink($this->getLocale());
-        }
+         return FluentState::singleton()->withState(function (FluentState $state) use ($record) {
+            $state->setLocale($this->getLocale());
+            $state->setIsFrontend(true);
 
-        // Get link from localised record
-        return $record->Link();
+            // If original record implements LocaleLink, respect this
+            // note: hasMethod() will infinite loop, so don't use this.
+            if (method_exists($record, 'LocaleLink')) {
+                return $record->LocaleLink($this->getLocale());
+            }
+
+            // Get link from localised record
+            return $record->Link();
+        });
     }
 
     /**


### PR DESCRIPTION
## Description
Wraps the Link() call within TractorCow\Fluent\Model\RecordLocale::getLink() in a withState() block to ensure the correct locale context is maintained for the entire duration of the recursive link generation.


## Manual testing steps
-Install Silverstripe CMS ^6.2.0 and silverstripe-fluent ^8.2.
-Create a nested page structure: Parent Page > Child Page.
-Localize both pages into two locales (e.g., Dutch nl_NL and English en_US).
-On the Dutch version of the Child Page, render a locale menu in the template using:

```
<% loop $Locales %>
        <a href="$Link">$Title</a>
  <% end_loop %>   
```

-Inspect the English link. The parent URL Segments should now be correctly localized 


## Issues
https://github.com/tractorcow-farm/silverstripe-fluent/issues/1027
- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [X] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [X] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [X] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [X] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [X] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [X] This change is covered with tests (or tests aren't necessary for this change)
- [X] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
