### PR TITLE
FIX Re-uniquify localised URLSegment after duplicate (#252)

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -694,6 +694,11 @@ class FluentExtension extends Extension
             }
         }
 
+        // Re-uniquify the localised URLSegment of the duplicated record per locale.
+        // The raw copy above replicates the original's URLSegment into each localised
+        // row, which collides with the original on the frontend (issue #252).
+        $this->makeDuplicateLocalisedURLSegmentsUnique($localisedTables, $owner->ID);
+
         // We need to handle duplicating relations in `localised_copy` into additional locales
 
         // We don't have any localised relations to cover
@@ -1744,5 +1749,80 @@ class FluentExtension extends Extension
         }
 
         return $locales;
+    }
+
+    /**
+     * After duplicating a record, the localised URLSegment values copied from the
+     * original collide with the original on the frontend. Re-uniquify each locale's
+     * URLSegment by appending a numeric suffix until no other record in the same
+     * locale uses it. Subclasses (e.g. FluentVersionedExtension) are responsible
+     * for syncing the resulting values into their _Versions tables.
+     *
+     * @param array<string, string[]> $localisedTables
+     */
+    protected function makeDuplicateLocalisedURLSegmentsUnique(array $localisedTables, int $recordID): void
+    {
+        foreach ($localisedTables as $tableName => $fields) {
+            if (!in_array('URLSegment', $fields, true)) {
+                continue;
+            }
+
+            $localisedTable = $this->getLocalisedTable($tableName);
+            $rows = DB::prepared_query(
+                sprintf('SELECT "ID", "Locale", "URLSegment" FROM "%s" WHERE "RecordID" = ?', $localisedTable),
+                [$recordID]
+            );
+
+            foreach ($rows as $row) {
+                $segment = (string) $row['URLSegment'];
+                if ($segment === '') {
+                    continue;
+                }
+                $unique = $this->generateUniqueLocalisedURLSegment(
+                    $localisedTable,
+                    (string) $row['Locale'],
+                    $segment,
+                    $recordID
+                );
+                if ($unique === $segment) {
+                    continue;
+                }
+                DB::prepared_query(
+                    sprintf('UPDATE "%s" SET "URLSegment" = ? WHERE "ID" = ?', $localisedTable),
+                    [$unique, $row['ID']]
+                );
+            }
+        }
+    }
+
+    private function generateUniqueLocalisedURLSegment(
+        string $localisedTable,
+        string $locale,
+        string $segment,
+        int $excludeRecordID
+    ): string {
+        $base = preg_replace('/-[0-9]+$/', '', $segment) ?: $segment;
+        $candidate = $segment;
+        $count = 2;
+        while ($this->localisedURLSegmentExists($localisedTable, $locale, $candidate, $excludeRecordID)) {
+            $candidate = $base . '-' . $count++;
+        }
+        return $candidate;
+    }
+
+    private function localisedURLSegmentExists(
+        string $localisedTable,
+        string $locale,
+        string $segment,
+        int $excludeRecordID
+    ): bool {
+        $count = DB::prepared_query(
+            sprintf(
+                'SELECT COUNT(*) FROM "%s" WHERE "Locale" = ? AND "URLSegment" = ? AND "RecordID" != ?',
+                $localisedTable
+            ),
+            [$locale, $segment, $excludeRecordID]
+        )->value();
+        return ((int) $count) > 0;
     }
 }

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -1120,6 +1120,29 @@ SQL;
                     FROM \"$localisedTable\"
                     WHERE \"RecordID\" = ?", [$toID, $fromID]);
 
+            // Sync URLSegment in the localised _Versions table to the value we just
+            // wrote to the live localised table (parent::onAfterDuplicate ensured
+            // those are unique per locale to avoid the duplicate-collision bug).
+            if (in_array('URLSegment', $fields, true)) {
+                $liveLocalisedTable = $this->getLocalisedTable($tableName);
+                $liveRows = DB::prepared_query(
+                    sprintf(
+                        'SELECT "Locale", "URLSegment" FROM "%s" WHERE "RecordID" = ?',
+                        $liveLocalisedTable
+                    ),
+                    [$toID]
+                );
+                foreach ($liveRows as $liveRow) {
+                    DB::prepared_query(
+                        sprintf(
+                            'UPDATE "%s" SET "URLSegment" = ? WHERE "RecordID" = ? AND "Locale" = ?',
+                            $localisedTable
+                        ),
+                        [$liveRow['URLSegment'], $toID, $liveRow['Locale']]
+                    );
+                }
+            }
+
             // Also copy versions of base record
             $versionsTableName = $tableName . FluentVersionedExtension::SUFFIX_VERSIONS;
 

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -521,6 +521,64 @@ class FluentSiteTreeExtensionTest extends SapphireTest
     }
 
     /**
+     * Regression test for #252: duplicating a page must produce a unique
+     * URLSegment in every localised row, not just the base table.
+     */
+    public function testDuplicateProducesUniqueLocalisedURLSegment(): void
+    {
+        FluentState::singleton()->withState(function (FluentState $state): void {
+            $state
+                ->setLocale('en_NZ')
+                ->setIsDomainMode(false);
+
+            $original = Page::create();
+            $original->Title = 'Innovation';
+            $original->URLSegment = 'innovation';
+            $original->write();
+
+            $duplicate = $original->duplicate();
+
+            // Base table is already de-duplicated by SiteTree::validURLSegment
+            $this->assertNotSame(
+                'innovation',
+                $duplicate->URLSegment,
+                'Base URLSegment should be unique after duplicate'
+            );
+
+            // The localised row for the current locale must also be unique
+            $localisedSegment = \SilverStripe\ORM\DB::prepared_query(
+                'SELECT "URLSegment" FROM "SiteTree_Localised" WHERE "RecordID" = ? AND "Locale" = ?',
+                [$duplicate->ID, 'en_NZ']
+            )->value();
+
+            $this->assertNotSame(
+                'innovation',
+                $localisedSegment,
+                'Localised URLSegment must not collide with the original (issue #252)'
+            );
+            $this->assertSame(
+                $duplicate->URLSegment,
+                $localisedSegment,
+                'Localised URLSegment should be kept in sync with the de-duplicated base value'
+            );
+
+            // _Versions row (latest version) must match too
+            $versionsSegment = \SilverStripe\ORM\DB::prepared_query(
+                'SELECT "URLSegment" FROM "SiteTree_Localised_Versions"
+                 WHERE "RecordID" = ? AND "Locale" = ?
+                 ORDER BY "Version" DESC LIMIT 1',
+                [$duplicate->ID, 'en_NZ']
+            )->value();
+
+            $this->assertSame(
+                $duplicate->URLSegment,
+                $versionsSegment,
+                'Localised _Versions URLSegment should match the live localised value'
+            );
+        });
+    }
+
+    /**
      * Normalises a test URL's trailing slash, but ignores complexities
      * such as whether the domain host in the UR matches Director::host()
      */


### PR DESCRIPTION
## Description

Fixes #252.

`FluentExtension::onAfterDuplicate` raw-copies the original record's localised rows into the duplicate (including `URLSegment`), bypassing `SiteTree::validURLSegment` which only de-duplicates against the base table. As a result the duplicate has a unique base `URLSegment` but its localised `URLSegment` still matches the original. On the frontend the duplicate becomes unreachable, and the CMS preview iframe re-routes the edit form back to the original page via the `x-page-id` / `x-cms-edit-link` meta-tag sync in `silverstripe-admin`'s `LeftAndMain.Preview.js::_loadCurrentPage`.

## Changes

- `FluentExtension::onAfterDuplicate`: after the localised copy, walk each locale row and append a numeric suffix until no other record in the same locale uses the same `URLSegment`. Per-locale uniqueness preserves translated slugs (e.g. `de=ueber-uns`, `en=about-us` become `ueber-uns-2`, `about-us-2`).
- `FluentVersionedExtension::onAfterDuplicate`: after the localised `_Versions` rows are copied from the original, sync their `URLSegment` per `(RecordID, Locale)` to whatever was written to the live localised table, so the version history stays consistent with the live record.
- Adds a regression test `FluentSiteTreeExtensionTest::testDuplicateProducesUniqueLocalisedURLSegment` asserting unique `URLSegment` in both `SiteTree_Localised` and `SiteTree_Localised_Versions` after `duplicate()`. Verified to fail against unpatched 8.2.0 with `"Localised URLSegment must not collide with the original (issue #252)"` and pass with the fix applied.

## Manual verification

Reproduced in a Silverstripe 6 / Fluent 8.2.0 project (page tree, duplicate via `CMSMain::duplicate`):
- Before: duplicate's `SiteTree_Localised.URLSegment` = original's value → frontend collision → CMS edit form bounces back to original.
- After: duplicate's localised URLSegment carries the `-2` suffix from `validURLSegment`; edit form stays on the new page; frontend URL is reachable.