### PR TITLE
FIX Re-uniquify localised URLSegment after duplicate (#252)

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -21,9 +21,9 @@ use SilverStripe\ORM\FieldType\DBHTMLVarchar;
 use SilverStripe\ORM\FieldType\DBText;
 use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\ORM\Queries\SQLConditionGroup;
+use SilverStripe\ORM\Queries\SQLInsert;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\Core\Validation\ValidationException;
-use SilverStripe\ORM\Queries\SQLUpdate;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\HTML;
 use TractorCow\Fluent\Extension\Traits\FluentBadgeTrait;
@@ -642,6 +642,13 @@ class FluentExtension extends Extension
 
     /**
      * If an object is duplicated also duplicate existing localised values from original to new object.
+     *
+     * Each localised row is read from the original, prepared via
+     * {@see self::prepareLocalisedRowForDuplicate()} (extension point for subclasses
+     * to mutate field values before they hit the DB), and then inserted as a single
+     * write per row. This avoids the previous DELETE + INSERT…SELECT + post-hoc
+     * UPDATE pattern and lets subclasses (e.g. FluentSiteTreeExtension) provide
+     * already-correct values rather than fix them up afterwards.
      */
     public function onAfterDuplicate($original, $doWrite, $relations): void
     {
@@ -663,35 +670,20 @@ class FluentExtension extends Extension
 
         // Add row for new duplicated page in all relevant localised tables
         foreach ($localisedTables as $tableName => $fields) {
-            // Target IDs
             $fromID = $original->ID;
             $toID = $owner->ID;
-
-            // Get localised table
             $localisedTable = $this->getLocalisedTable($tableName);
 
-            // Remove existing translations from duplicated object
-            DB::prepared_query("DELETE FROM \"$localisedTable\" WHERE \"RecordID\" = ?", [$toID]);
-
-            // Copy translations to duplicated object
-            $fields_str = '"' . implode('","', $fields) . '"';
-            DB::prepared_query("INSERT INTO \"$localisedTable\" ( \"RecordID\", \"Locale\", $fields_str)
-                    SELECT ? AS \"RecordID\", \"Locale\", $fields_str
-                    FROM \"$localisedTable\"
-                    WHERE \"RecordID\" = ?", [$toID, $fromID]);
-
-            // Make sure to update any has_one IDs - otherwise the new localised table entry will
-            // have the has_one ID from the original record.
-            // The current $owner (i.e. the newly duplicated record) may have already had its relation duplicated
-            // via cascade_duplicates prior to this extension hook being called.
-            // This only covers the current locale - see below for handling additional locales.
-            $fieldsToUpdate = [];
-            foreach (array_intersect($fields, $copyHasOneRelations) as $copyFieldName) {
-                $fieldsToUpdate[$copyFieldName] = $owner->{$copyFieldName};
-            }
-            if (!empty($fieldsToUpdate)) {
-                SQLUpdate::create($localisedTable, $fieldsToUpdate, ['RecordID' => $toID])->execute();
-            }
+            $this->duplicateLocalisedRows(
+                $tableName,
+                $localisedTable,
+                $fields,
+                $fromID,
+                $toID,
+                $original,
+                $owner,
+                $copyHasOneRelations
+            );
         }
 
         // We need to handle duplicating relations in `localised_copy` into additional locales
@@ -932,6 +924,80 @@ class FluentExtension extends Extension
 
         // Save back modifications to the manipulation
         $manipulation[$localeTable] = $localisedUpdate;
+    }
+
+    /**
+     * Replace every localised row of the duplicate with a per-row INSERT prepared from the
+     * original's localised rows. Allows subclasses to override
+     * {@see self::prepareLocalisedRowForDuplicate()} so they can supply already-correct
+     * values (e.g. a unique URLSegment) instead of fixing them up afterwards.
+     */
+    protected function duplicateLocalisedRows(
+        string $tableName,
+        string $localisedTable,
+        array $fields,
+        int $fromID,
+        int $toID,
+        DataObject $original,
+        DataObject $duplicate,
+        array $copyHasOneRelations
+    ): void {
+        $columns = array_merge(['RecordID', 'Locale'], $fields);
+        $columnList = '"' . implode('","', $columns) . '"';
+        $sourceRows = DB::prepared_query(
+            "SELECT $columnList FROM \"$localisedTable\" WHERE \"RecordID\" = ?",
+            [$fromID]
+        );
+
+        // Remove the localised row(s) that the initial duplicate write created so we can re-insert
+        // from the source row data in a controlled, single write per row.
+        DB::prepared_query("DELETE FROM \"$localisedTable\" WHERE \"RecordID\" = ?", [$toID]);
+
+        // The original SQLUpdate did not filter by locale, so all locales received the current
+        // locale's has_one IDs (and the later FluentState loop re-wrote non-current locales).
+        // Preserve that behaviour by applying the override to every prepared row.
+        $hasOneOverrides = [];
+        foreach (array_intersect($fields, $copyHasOneRelations) as $copyFieldName) {
+            $hasOneOverrides[$copyFieldName] = $duplicate->{$copyFieldName};
+        }
+
+        foreach ($sourceRows as $row) {
+            $row['RecordID'] = $toID;
+            foreach ($hasOneOverrides as $field => $value) {
+                $row[$field] = $value;
+            }
+            $row = $this->prepareLocalisedRowForDuplicate(
+                $tableName,
+                $localisedTable,
+                $row,
+                $original,
+                $duplicate
+            );
+
+            SQLInsert::create("\"$localisedTable\"", $row)->execute();
+        }
+    }
+
+    /**
+     * Extension point for subclasses: transform a single localised row before it is
+     * inserted into the duplicate's localised table. The returned array is written as-is,
+     * so subclasses can pre-compute values (e.g. uniquify URLSegment) instead of fixing
+     * them up with a follow-up UPDATE.
+     *
+     * @param string $tableName Base table the localised values belong to
+     * @param string $localisedTable Fully-qualified localised table name being written to
+     * @param array $row Row data keyed by column name (RecordID already pointing at the duplicate)
+     * @param DataObject $original The record being duplicated from
+     * @param DataObject $duplicate The newly created duplicate ($this->getOwner())
+     */
+    protected function prepareLocalisedRowForDuplicate(
+        string $tableName,
+        string $localisedTable,
+        array $row,
+        DataObject $original,
+        DataObject $duplicate
+    ): array {
+        return $row;
     }
 
     /**

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -953,9 +953,6 @@ class FluentExtension extends Extension
         // from the source row data in a controlled, single write per row.
         DB::prepared_query("DELETE FROM \"$localisedTable\" WHERE \"RecordID\" = ?", [$toID]);
 
-        // The original SQLUpdate did not filter by locale, so all locales received the current
-        // locale's has_one IDs (and the later FluentState loop re-wrote non-current locales).
-        // Preserve that behaviour by applying the override to every prepared row.
         $hasOneOverrides = [];
         foreach (array_intersect($fields, $copyHasOneRelations) as $copyFieldName) {
             $hasOneOverrides[$copyFieldName] = $duplicate->{$copyFieldName};

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -12,7 +12,10 @@ use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\LiteralField;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBHTMLText;
+use SilverStripe\View\Parsers\URLSegmentFilter;
 use TractorCow\Fluent\Extension\Traits\FluentAdminTrait;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
@@ -426,5 +429,150 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
     public function actionComplete($form, $message)
     {
         return null;
+    }
+
+    /**
+     * Per-locale URLSegment values resolved during this duplicate operation.
+     * Populated by {@see self::prepareLocalisedRowForDuplicate()} and reused by
+     * {@see self::prepareLocalisedVersionRowForDuplicate()} so live and versioned
+     * rows stay in sync without a second uniqueness lookup.
+     *
+     * @var array<string,string>
+     */
+    private array $resolvedLocalisedURLSegments = [];
+
+    /**
+     * Uniquify URLSegment for each localised row before it is inserted.
+     *
+     * FluentExtension::onAfterDuplicate previously copied the original record's localised
+     * URLSegment verbatim. SiteTree::validURLSegment only de-duplicates the base table, so
+     * the duplicate ended up with a colliding localised URLSegment — unreachable on the
+     * frontend (issue #252) and re-routed by the CMS preview iframe via x-page-id /
+     * x-cms-edit-link sync. Hooking into the new row-prep extension point means we can
+     * write the correct value once instead of fixing it up afterwards.
+     */
+    protected function prepareLocalisedRowForDuplicate(
+        string $tableName,
+        string $localisedTable,
+        array $row,
+        DataObject $original,
+        DataObject $duplicate
+    ): array {
+        $row = parent::prepareLocalisedRowForDuplicate($tableName, $localisedTable, $row, $original, $duplicate);
+
+        if (!array_key_exists('URLSegment', $row)) {
+            return $row;
+        }
+
+        $segment = (string) $row['URLSegment'];
+        if ($segment === '') {
+            return $row;
+        }
+
+        $unique = $this->generateUniqueLocalisedURLSegment(
+            $localisedTable,
+            $tableName,
+            (string) $row['Locale'],
+            $segment,
+            (int) $duplicate->ID,
+            $this->getDuplicateParentScope($duplicate)
+        );
+
+        $row['URLSegment'] = $unique;
+        $this->resolvedLocalisedURLSegments[(string) $row['Locale']] = $unique;
+
+        return $row;
+    }
+
+    /**
+     * Apply the same URLSegment that was chosen for the live row to every version row of the
+     * same locale. Keeps Live and _Versions tables consistent and avoids a second uniqueness
+     * lookup.
+     */
+    protected function prepareLocalisedVersionRowForDuplicate(
+        string $tableName,
+        string $versionsLocalisedTable,
+        array $row,
+        DataObject $original,
+        DataObject $duplicate
+    ): array {
+        $row = parent::prepareLocalisedVersionRowForDuplicate(
+            $tableName,
+            $versionsLocalisedTable,
+            $row,
+            $original,
+            $duplicate
+        );
+
+        if (!array_key_exists('URLSegment', $row)) {
+            return $row;
+        }
+
+        $locale = (string) $row['Locale'];
+        if (isset($this->resolvedLocalisedURLSegments[$locale])) {
+            $row['URLSegment'] = $this->resolvedLocalisedURLSegments[$locale];
+        }
+
+        return $row;
+    }
+
+    /**
+     * Determine the ParentID scope to use for URLSegment uniqueness for the given duplicate.
+     * Returns null when the class does not use nested URLs (uniqueness is global per locale).
+     */
+    private function getDuplicateParentScope(DataObject $duplicate): ?int
+    {
+        $nestedUrls = (bool) $duplicate::config()->get('nested_urls');
+        if (!$nestedUrls || !$duplicate->hasField('ParentID')) {
+            return null;
+        }
+        return (int) ($duplicate->ParentID ?: 0);
+    }
+
+    private function generateUniqueLocalisedURLSegment(
+        string $localisedTable,
+        string $baseTable,
+        string $locale,
+        string $segment,
+        int $excludeRecordID,
+        ?int $parentID
+    ): string {
+        $filter = URLSegmentFilter::create();
+        $segment = $filter->filter($segment) ?: $segment;
+        $base = preg_replace('/-[0-9]+$/', '', $segment) ?: $segment;
+        $candidate = $segment;
+        // If the segment already ends in a number, continue counting from there.
+        $count = preg_match('/-([0-9]+)$/', $segment, $matches) ? (int) $matches[1] + 1 : 2;
+        while ($this->localisedURLSegmentExists($localisedTable, $baseTable, $locale, $candidate, $excludeRecordID, $parentID)) {
+            $candidate = $base . '-' . $count++;
+        }
+        return $candidate;
+    }
+
+    private function localisedURLSegmentExists(
+        string $localisedTable,
+        string $baseTable,
+        string $locale,
+        string $segment,
+        int $excludeRecordID,
+        ?int $parentID
+    ): bool {
+        if ($parentID === null) {
+            $sql = sprintf(
+                'SELECT COUNT(*) FROM "%s" WHERE "Locale" = ? AND "URLSegment" = ? AND "RecordID" != ?',
+                $localisedTable
+            );
+            $params = [$locale, $segment, $excludeRecordID];
+        } else {
+            $sql = sprintf(
+                'SELECT COUNT(*) FROM "%s" loc INNER JOIN "%s" base ON base."ID" = loc."RecordID"'
+                . ' WHERE loc."Locale" = ? AND loc."URLSegment" = ? AND loc."RecordID" != ? AND base."ParentID" = ?',
+                $localisedTable,
+                $baseTable
+            );
+            $params = [$locale, $segment, $excludeRecordID, $parentID];
+        }
+        $count = DB::prepared_query($sql, $params)->value();
+        return ((int) $count) > 0;
     }
 }

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -11,6 +11,7 @@ use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLInsert;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\Versioned\Versioned;
 use TractorCow\Fluent\Forms\PublishAction;
@@ -1093,32 +1094,31 @@ SQL;
 
     /**
      * If an object is duplicated also duplicate existing localised values from original to new object.
+     *
+     * Mirrors the parent's row-by-row approach for the localised `_Versions` tables so that
+     * subclasses can override {@see self::prepareLocalisedVersionRowForDuplicate()} and supply
+     * the correct values up-front (e.g. the same uniquified URLSegment used for the live row).
      */
     public function onAfterDuplicate($original, $doWrite, $relations): void
     {
         parent::onAfterDuplicate($original, $doWrite, $relations);
 
+        $fromID = $original->ID;
+        $toID = $this->owner->ID;
+
         $localisedTables = $this->owner->getLocalisedTables();
         foreach ($localisedTables as $tableName => $fields) {
-            // Target IDs
-            $fromID = $original->ID;
-            $toID = $this->owner->ID;
+            $versionsLocalisedTable = $this->getLocalisedTable($tableName) . FluentVersionedExtension::SUFFIX_VERSIONS;
 
-            // Get localised table
-            $localisedTable = $this->getLocalisedTable($tableName) . FluentVersionedExtension::SUFFIX_VERSIONS;
-
-            // Remove existing translation versions from duplicated object
-            DB::prepared_query("DELETE FROM \"$localisedTable\" WHERE \"RecordID\" = ?", [$toID]);
-
-            // Copy translations to duplicated object
-            $localisedFields = array_merge(['Locale', 'Version'], $fields);
-            $fields_str = '"' . implode('","', $localisedFields) . '"';
-
-            // Copy all versions of localised object
-            DB::prepared_query("INSERT INTO \"$localisedTable\" ( \"RecordID\", $fields_str)
-                    SELECT ? AS \"RecordID\", $fields_str
-                    FROM \"$localisedTable\"
-                    WHERE \"RecordID\" = ?", [$toID, $fromID]);
+            $this->duplicateLocalisedVersionRows(
+                $tableName,
+                $versionsLocalisedTable,
+                $fields,
+                $fromID,
+                $toID,
+                $original,
+                $this->owner
+            );
 
             // Also copy versions of base record
             $versionsTableName = $tableName . FluentVersionedExtension::SUFFIX_VERSIONS;
@@ -1130,12 +1130,71 @@ SQL;
             $currentDB = DB::query('SELECT DATABASE() as DB')->column('DB')[0];
 
             // Copy all versions of base record, todo: optimize to only copy needed versions
-            $fields = DB::query("SELECT \"COLUMN_NAME\" FROM \"INFORMATION_SCHEMA\".\"COLUMNS\" WHERE \"TABLE_SCHEMA\" = '$currentDB' AND \"TABLE_NAME\" = '$versionsTableName' AND \"COLUMN_NAME\" NOT IN('ID','RecordID')");
-            $fields_str = '"' . implode('","', $fields->column()) . '"';
+            $baseVersionFields = DB::query("SELECT \"COLUMN_NAME\" FROM \"INFORMATION_SCHEMA\".\"COLUMNS\" WHERE \"TABLE_SCHEMA\" = '$currentDB' AND \"TABLE_NAME\" = '$versionsTableName' AND \"COLUMN_NAME\" NOT IN('ID','RecordID')");
+            $fields_str = '"' . implode('","', $baseVersionFields->column()) . '"';
             DB::prepared_query("INSERT INTO \"$versionsTableName\" ( \"RecordID\", $fields_str)
                     SELECT ? AS \"RecordID\", $fields_str
                     FROM \"$versionsTableName\"
                     WHERE \"RecordID\" = ?", [$toID, $fromID]);
         }
+    }
+
+    /**
+     * Replace localised `_Versions` rows of the duplicate with rows prepared per source row.
+     * The hook {@see self::prepareLocalisedVersionRowForDuplicate()} lets subclasses mutate
+     * values (e.g. URLSegment) before they are written.
+     */
+    protected function duplicateLocalisedVersionRows(
+        string $tableName,
+        string $versionsLocalisedTable,
+        array $fields,
+        int $fromID,
+        int $toID,
+        DataObject $original,
+        DataObject $duplicate
+    ): void {
+        $columns = array_merge(['RecordID', 'Locale', 'Version'], $fields);
+        $columnList = '"' . implode('","', $columns) . '"';
+        $sourceRows = DB::prepared_query(
+            "SELECT $columnList FROM \"$versionsLocalisedTable\" WHERE \"RecordID\" = ?",
+            [$fromID]
+        );
+
+        DB::prepared_query("DELETE FROM \"$versionsLocalisedTable\" WHERE \"RecordID\" = ?", [$toID]);
+
+        foreach ($sourceRows as $row) {
+            $row['RecordID'] = $toID;
+            $row = $this->prepareLocalisedVersionRowForDuplicate(
+                $tableName,
+                $versionsLocalisedTable,
+                $row,
+                $original,
+                $duplicate
+            );
+
+            SQLInsert::create("\"$versionsLocalisedTable\"", $row)->execute();
+        }
+    }
+
+    /**
+     * Extension point for subclasses: transform a single localised `_Versions` row before it is
+     * inserted into the duplicate's localised versions table. Subclasses should typically reuse
+     * the value chosen in {@see FluentExtension::prepareLocalisedRowForDuplicate()} for the same
+     * locale to keep live and version history consistent.
+     *
+     * @param string $tableName Base table the versioned localised values belong to
+     * @param string $versionsLocalisedTable Fully-qualified `_Localised_Versions` table name
+     * @param array $row Row data keyed by column name (RecordID already pointing at the duplicate)
+     * @param DataObject $original The record being duplicated from
+     * @param DataObject $duplicate The newly created duplicate ($this->owner)
+     */
+    protected function prepareLocalisedVersionRowForDuplicate(
+        string $tableName,
+        string $versionsLocalisedTable,
+        array $row,
+        DataObject $original,
+        DataObject $duplicate
+    ): array {
+        return $row;
     }
 }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -12,6 +12,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Model\List\ArrayList;
+use SilverStripe\ORM\DB;
 use SilverStripe\Core\Validation\ValidationException;
 use SilverStripe\Versioned\Versioned;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
@@ -518,6 +519,181 @@ class FluentSiteTreeExtensionTest extends SapphireTest
                 0,
             ],
         ];
+    }
+
+    /**
+     * Regression test for #252: duplicating a page must produce a unique
+     * URLSegment in every localised row, not just the base table. Covers
+     * multiple locales — each locale's URLSegment is uniquified
+     * independently, preserving translated slugs.
+     */
+    public function testDuplicateProducesUniqueLocalisedURLSegment(): void
+    {
+        // Set up the original page with different URLSegments per locale
+        $originalID = FluentState::singleton()->withState(function (FluentState $state): int {
+            $state
+                ->setLocale('de_DE')
+                ->setIsDomainMode(false);
+
+            $page = Page::create();
+            $page->Title = 'Innovation';
+            $page->URLSegment = 'innovation';
+            $page->write();
+
+            return (int) $page->ID;
+        });
+
+        // Localise the page into en_US with a different slug
+        FluentState::singleton()->withState(function (FluentState $state) use ($originalID): void {
+            $state
+                ->setLocale('en_US')
+                ->setIsDomainMode(false);
+
+            $page = Page::get()->byID($originalID);
+            $page->URLSegment = 'innovation-en';
+            $page->write();
+        });
+
+        // Duplicate while in the default locale
+        FluentState::singleton()->withState(function (FluentState $state) use ($originalID): void {
+            $state
+                ->setLocale('de_DE')
+                ->setIsDomainMode(false);
+
+            $duplicate = Page::get()->byID($originalID)->duplicate();
+
+            // Base table is already de-duplicated by SiteTree::validURLSegment
+            $this->assertNotSame(
+                'innovation',
+                $duplicate->URLSegment,
+                'Base URLSegment should be unique after duplicate'
+            );
+
+            // de_DE locale row matches the de-duplicated base value
+            $deSegment = DB::prepared_query(
+                'SELECT "URLSegment" FROM "SiteTree_Localised" WHERE "RecordID" = ? AND "Locale" = ?',
+                [$duplicate->ID, 'de_DE']
+            )->value();
+            $this->assertNotSame(
+                'innovation',
+                $deSegment,
+                'de_DE localised URLSegment must not collide with the original (issue #252)'
+            );
+            $this->assertSame(
+                $duplicate->URLSegment,
+                $deSegment,
+                'de_DE localised URLSegment should match the de-duplicated base value'
+            );
+
+            // en_US locale row is uniquified independently from its own original
+            // value, not from the de_DE slug. Expectation: 'innovation-en' -> 'innovation-en-2'.
+            $usSegment = DB::prepared_query(
+                'SELECT "URLSegment" FROM "SiteTree_Localised" WHERE "RecordID" = ? AND "Locale" = ?',
+                [$duplicate->ID, 'en_US']
+            )->value();
+            $this->assertNotSame(
+                'innovation-en',
+                $usSegment,
+                'en_US localised URLSegment must not collide with the original'
+            );
+            $this->assertSame(
+                'innovation-en-2',
+                $usSegment,
+                'en_US localised URLSegment should be derived from the en_US slug, not the default locale'
+            );
+
+            // _Versions rows mirror the live localised values per locale
+            $deVersion = DB::prepared_query(
+                'SELECT "URLSegment" FROM "SiteTree_Localised_Versions"'
+                . ' WHERE "RecordID" = ? AND "Locale" = ? ORDER BY "Version" DESC LIMIT 1',
+                [$duplicate->ID, 'de_DE']
+            )->value();
+            $this->assertSame(
+                $deSegment,
+                $deVersion,
+                'de_DE _Versions URLSegment should match the live row'
+            );
+            $usVersion = DB::prepared_query(
+                'SELECT "URLSegment" FROM "SiteTree_Localised_Versions"'
+                . ' WHERE "RecordID" = ? AND "Locale" = ? ORDER BY "Version" DESC LIMIT 1',
+                [$duplicate->ID, 'en_US']
+            )->value();
+            $this->assertSame(
+                $usSegment,
+                $usVersion,
+                'en_US _Versions URLSegment should match the live row'
+            );
+        });
+    }
+
+    /**
+     * Regression test for #252 / #1031 review: ensure parent scoping is
+     * respected — duplicating a page must only bump its URLSegment based on
+     * siblings under the same parent, not unrelated pages elsewhere in the
+     * tree. With nested_urls = true (the SiteTree default), /foo/bar and
+     * /baz/bar are valid distinct URLs.
+     */
+    public function testDuplicateRespectsParentScope(): void
+    {
+        FluentState::singleton()->withState(function (FluentState $state): void {
+            $state
+                ->setLocale('de_DE')
+                ->setIsDomainMode(false);
+
+            // /foo
+            $foo = Page::create();
+            $foo->Title = 'Foo';
+            $foo->URLSegment = 'foo';
+            $foo->write();
+
+            // /bar
+            $bar = Page::create();
+            $bar->Title = 'Bar';
+            $bar->URLSegment = 'bar';
+            $bar->write();
+
+            // /foo/innovation-2 (unrelated sibling that would falsely bump
+            // a globally-scoped uniqueness check to "-3")
+            $fooChild = Page::create();
+            $fooChild->Title = 'Innovation';
+            $fooChild->URLSegment = 'innovation-2';
+            $fooChild->ParentID = $foo->ID;
+            $fooChild->write();
+
+            // /bar/innovation
+            $barChild = Page::create();
+            $barChild->Title = 'Innovation';
+            $barChild->URLSegment = 'innovation';
+            $barChild->ParentID = $bar->ID;
+            $barChild->write();
+
+            $duplicate = $barChild->duplicate();
+
+            // Base URLSegment is parent-scoped by SiteTree itself, so it lands on innovation-2
+            $this->assertSame(
+                'innovation-2',
+                $duplicate->URLSegment,
+                'Base URLSegment should be uniquified within the same parent'
+            );
+
+            $localisedSegment = DB::prepared_query(
+                'SELECT "URLSegment" FROM "SiteTree_Localised" WHERE "RecordID" = ? AND "Locale" = ?',
+                [$duplicate->ID, 'de_DE']
+            )->value();
+
+            // With parent scoping in the Fluent fix, the localised value also lands on innovation-2
+            // (the /foo/innovation-2 sibling lives under a different parent and is irrelevant).
+            $this->assertSame(
+                'innovation-2',
+                $localisedSegment,
+                'Localised URLSegment must be parent-scoped, not bumped by an unrelated /foo/innovation-2'
+            );
+            $this->assertSame(
+                $duplicate->URLSegment,
+                $localisedSegment,
+                'Localised and base URLSegments must stay in sync'
+            );
+        });
     }
 
     /**


### PR DESCRIPTION
## Description

onAfterDuplicate raw-copies the original record's localised rows into the duplicate (including URLSegment), bypassing SiteTree::validURLSegment which only checks the base table. The duplicate ends up with a unique base URLSegment but a colliding localised URLSegment, which makes the duplicate unreachable on the frontend and causes the CMS preview to re-route the edit form to the original page via the x-page-id/x-cms-edit-link sync.

After the localised copy, walk each locale row and append a numeric suffix until no other record in the same locale uses the same URLSegment. Mirror the resulting value into the localised _Versions table so version history stays consistent with the live record.

Adds a regression test on FluentSiteTreeExtensionTest that asserts unique URLSegments in both the live and _Versions localised tables after duplicate.

## Manual testing steps

On a Silverstripe CMS 6 installation with fluent: Use the duplicate function in the tree. The duplicate will have a different URLSegment and you can edit it.

## Issues
#252 

## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
